### PR TITLE
[FEAT] portfolio Create, Read api

### DIFF
--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -1,0 +1,65 @@
+const Portfolio = require("../models/Portfolio");
+
+// 포트폴리오 목록 조회
+const getAllPortfolios = async (req, res) => {
+  try {
+    const portfolios = await Portfolio.find()
+      .sort({ createdAt: -1 }) // 최신순 정렬
+      .select("-__v"); // __v 필드 제외하고 클라이언트에 보여줌
+
+    res.status(200).json({
+      success: true,
+      count: portfolios.length,
+      data: portfolios,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: "포트폴리오 목록을 가져오는데 실패했습니다.",
+    });
+  }
+};
+
+// 새 포트폴리오 생성
+const createPortfolio = async (req, res) => {
+  try {
+    const {
+      title,
+      contents,
+      images,
+      tags,
+      techStack,
+      jobGroup,
+      thumbnailImage,
+      userID,
+    } = req.body;
+
+    const portfolio = new Portfolio({
+      title,
+      contents,
+      images,
+      tags,
+      techStack,
+      jobGroup,
+      thumbnailImage,
+      userID,
+    });
+
+    const savedPortfolio = await portfolio.save();
+
+    res.status(201).json({
+      success: true,
+      data: savedPortfolio,
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      error: error.message || "포트폴리오 생성에 실패했습니다.",
+    });
+  }
+};
+
+module.exports = {
+  getAllPortfolios,
+  createPortfolio,
+};

--- a/index.js
+++ b/index.js
@@ -10,14 +10,35 @@ const mongoose = require("mongoose");
 const app = express();
 const port = process.env.PORT || 8000;
 
-// 데이터베이스 연결
-mongoose
-  .connect(process.env.MONGO_URI)
-  .then(() => console.log("MongoDB 연결 성공"))
-  .catch((err) => console.error("MongoDB 연결 실패:", err));
+// MongoDB 연결 설정
+const connectDB = async () => {
+  try {
+    const conn = await mongoose.connect(process.env.MONGO_URI, {
+      dbName: "devporest", // 데이터베이스 이름을 'devporest'로 설정(default: 'test')
+    });
+    console.log(`MongoDB 연결 성공: ${conn.connection.host}`);
+  } catch (error) {
+    console.error("MongoDB 연결 실패:", error);
+    process.exit(1);
+  }
+};
+// MongoDB 연결
+connectDB();
+
+const corsOptions = {
+  origin: [
+    process.env.CORS_ORIGIN,
+    "http://localhost:5173", // React 개발 서버
+    "http://localhost:8000", // Express 서버
+    /localhost:\d+$/, // localhost의 모든 포트 허용
+  ],
+  credentials: true, // 응답 헤더에 Access-Control-Allow-Credentials 추가
+  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  allowedHeaders: ["Content-Type", "Authorization"],
+};
 
 // 미들웨어 설정
-app.use(cors({ origin: process.env.CORS_ORIGIN }));
+app.use(cors(corsOptions));
 app.use(express.json()); // JSON 파싱
 app.use(cookieParser()); // 쿠키 파싱
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs)); // Swagger UI를 /api-docs 경로에 라우팅
@@ -27,15 +48,17 @@ app.get("/", (req, res) => {
   res.send("Express 서버가 실행 중입니다.");
 });
 
-// 존재하지 않는 라우트에 대한 처리
-app.use("*", (req, res) => {
-  res.status(404).json({ message: "요청하신 페이지를 찾을 수 없습니다." });
-});
-
-// 추가적인 라우터를 추가하려면, routes 폴더에 파일을 추가하고, 이곳에서 불러오면 됨
+// API 라우트 설정
+const apiRoutes = require("./routes");
+app.use("/api", apiRoutes);
 
 // 서버 시작
 app.listen(port, () => {
   console.log(`서버가 ${port}번 포트에서 실행 중입니다...`);
   console.log(`CORS origin: ${process.env.CORS_ORIGIN}`);
+});
+
+// 존재하지 않는 라우트에 대한 처리
+app.use("*", (req, res) => {
+  res.status(404).json({ message: "요청하신 페이지를 찾을 수 없습니다." });
 });

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -3,11 +3,7 @@ const Schema = mongoose.Schema;
 
 const portfolioSchema = new Schema(
   {
-    portfolioID: {
-      type: String,
-      required: true,
-      unique: true,
-    },
+    // _id : 자동생성됨
     title: {
       type: String,
       required: true,
@@ -58,7 +54,6 @@ const portfolioSchema = new Schema(
 );
 
 // 1은 오름차순, -1은 내림차순 정렬을 의미합니다
-portfolioSchema.index({ portfolioID: 1 }); // portfolioID로 특정 포트폴리오 검색 시 성능 향상
 portfolioSchema.index({ userID: 1 }); // 특정 사용자의 모든 포트폴리오 검색 시 성능 향상
 portfolioSchema.index({ jobGroup: 1 }); // 특정 직군의 포트폴리오 목록 검색 시 성능 향상
 portfolioSchema.index({ createdAt: -1 }); // 최신순 정렬 시 성능 향상

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+
+// 라우트 파일들을 import
+const portfolioRoutes = require("./portfolioRoutes");
+
+// API 라우트 설정
+router.use("/portfolios", portfolioRoutes);
+
+module.exports = router;

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -1,0 +1,140 @@
+/**
+ * @swagger
+ * tags:
+ *   name: Portfolios
+ *   description: 포트폴리오 관리 API
+ */
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Portfolio:
+ *       type: object
+ *       required:
+ *         - title
+ *         - contents
+ *         - userID
+ *       properties:
+ *         title:
+ *           type: string
+ *           description: 포트폴리오 제목
+ *         contents:
+ *           type: string
+ *           description: 포트폴리오 내용
+ *         images:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: 이미지 URL 배열
+ *         tags:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: 태그 배열
+ *         techStack:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: 사용된 기술 스택 배열
+ *         jobGroup:
+ *           type: number
+ *           description: 직무 카테고리
+ *         thumbnailImage:
+ *           type: string
+ *           description: 썸네일 이미지 URL(단일)
+ *         userID:
+ *           type: string
+ *           description: 포트폴리오 소유자 ID
+ */
+
+/**
+ * @swagger
+ * /api/portfolios:
+ *   get:
+ *     summary: 전체 포트폴리오 조회
+ *     tags: [Portfolios]
+ *     responses:
+ *       200:
+ *         description: 포트폴리오 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 count:
+ *                   type: number
+ *                   description: 전체 포트폴리오 수
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Portfolio'
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 포트폴리오 목록을 가져오는데 실패했습니다.
+ */
+
+/**
+ * @swagger
+ * /api/portfolios:
+ *   post:
+ *     summary: 새 포트폴리오 생성
+ *     tags: [Portfolios]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Portfolio'
+ *     responses:
+ *       201:
+ *         description: 포트폴리오 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   $ref: '#/components/schemas/Portfolio'
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 포트폴리오 생성에 실패했습니다.
+ */
+
+const express = require("express");
+const router = express.Router();
+const portfolioController = require("../controllers/portfolioController.js");
+
+// GET /api/portfolios
+router.get("/", portfolioController.getAllPortfolios);
+
+// POST /api/portfolios
+router.post("/", portfolioController.createPortfolio);
+
+module.exports = router;

--- a/swagger/index.js
+++ b/swagger/index.js
@@ -18,7 +18,7 @@ const options = {
     },
     servers: [
       {
-        url: `http://localhost:/${port}`,
+        url: `http://localhost:${port}`,
         description: "Local Development",
       },
     ],


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약  
- **Routes**: `routes/index.js`로 API 라우트 중앙 집중화  
- **API 작성**: `/api/portfolio` GET, POST API 작성 및 Swagger에 반영  
- **DB 설정**: CORS 재설정 및 MongoDB 연결 시 `dbName` 사용  
- **Portfolio 스키마 변경**: `portfolioID` 필드 삭제, `_id` 필드 이용  

---

## 📌 이슈 넘버  
- #8
---

## 📝 작업 내용  
1. **CORS 재설정 및 Swagger 서버 URL 수정**  
   - 외부 API와의 통신 문제를 해결하기 위해 CORS 설정 변경  
   - Swagger 서버 URL을 소폭 수정, 통신에러 해결

2. **MongoDB 연결 시 dbName 사용**  
   - 데이터베이스 연결 시 `dbName`을 명시적으로 지정하도록 변경  
   ```javascript
   mongoose.connect(process.env.MONGO_URI, {
     dbName: "devoprest",
   });

3. **API 라우트 중앙 집중화**  
   - `routes/index.js`에 모든 API 라우트 등록  
   - 새로운 API 추가 시 `routes/index.js`를 통해 관리  
   ```javascript
   const portfolioRoutes = require('./portfolioRoutes');
   router.use("/portfolios", portfolioRoutes);

4. Portfolio 스키마 변경
   - portfolioID 필드 삭제
   - MongoDB에서 자동 생성되는 _id 필드로 대체하여 관리

## 💬 리뷰 요구사항 (선택)
/api 가 번거롭게 쓰이지 않도록 API 라우트 중앙 집중화 한게 맞는지 확인부탁드립니다!