### PR TITLE
[FEAT] User API CRUD 구현 

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -55,7 +55,11 @@ const getGithubCallback = async (req, res) => {
     }).then((res) => res.json());
 
     // 가져온 유저 ID를 JWT로 변환
-    const token = jwt.sign({ id: userData.login }, secret, {});
+    const token = jwt.sign(
+      { id: userData.login, access_token: accessToken },
+      secret,
+      {}
+    );
 
     // cookie에 JWT를 넣어준다.
     res

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -60,7 +60,47 @@ const registerUserProfile = async (req, res) => {
   }
 };
 
+const modifyUserProfile = async (req, res) => {
+  const { id } = req.userinfo;
+
+  try {
+    //github 정보인 name과 userID 변경 방지
+    if (req.body["name"] || req.body["userID"]) {
+      return res.status(400).json({
+        success: false,
+        error: "잘못된 접근입니다.",
+      });
+    }
+
+    const userDoc = await User.findOneAndUpdate(
+      { userID: id },
+      {
+        ...req.body,
+      }
+    );
+
+    // 만약 user가 없을 경우
+    if (!userDoc) {
+      return res.status(404).json({
+        success: false,
+        error: "해당 ID의 유저를 찾을 수 없습니다.",
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      data: userDoc,
+    });
+  } catch (err) {
+    res.status(400).json({
+      success: false,
+      error: err.message || "유저 프로필 수정에 실패했습니다.",
+    });
+  }
+};
+
 module.exports = {
   getUserInfo,
   registerUserProfile,
+  modifyUserProfile,
 };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,22 @@
+const User = require("../models/User");
+const mongoose = require("mongoose");
+
+const getUserInfo = async (req, res) => {
+  const { userid } = req.params;
+
+  try {
+    const userDoc = await User.findOne({ userID: userid });
+
+    if (!userDoc) {
+      return res.status(404).json({ message: "사용자정보를 찾을 수 없어요" });
+    }
+
+    res.json(userDoc);
+  } catch (err) {
+    res.status(500).json({ message: "서버에러" });
+  }
+};
+
+module.exports = {
+  getUserInfo,
+};

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -11,12 +11,56 @@ const getUserInfo = async (req, res) => {
       return res.status(404).json({ message: "사용자정보를 찾을 수 없어요" });
     }
 
+    /* 포트폴리오 가져오는 코드 추가해야 함 **/
+
     res.json(userDoc);
   } catch (err) {
     res.status(500).json({ message: "서버에러" });
   }
 };
 
+const registerUserProfile = async (req, res) => {
+  const { id, access_token } = req.userinfo;
+
+  // AccessToken을 사용하여 Github 유저 정보 가져오기
+  const userData = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+    },
+  }).then((res) => res.json());
+
+  const {
+    email,
+    phoneNumber,
+    links,
+    intro,
+    profileImage,
+    techStack,
+    jobGroup,
+  } = req.body;
+
+  try {
+    const userDoc = await User.create({
+      userID: id,
+      name: userData.name,
+      links,
+      email,
+      phoneNumber,
+      intro,
+      profileImage,
+      techStack,
+      jobGroup,
+    });
+    res.json(userDoc);
+  } catch (err) {
+    res.status(500).json({
+      message: "유저 프로필 등록 중 오류가 발생했습니다.",
+      error: err,
+    });
+  }
+};
+
 module.exports = {
   getUserInfo,
+  registerUserProfile,
 };

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -15,7 +15,7 @@ const auth = (req, res, next) => {
     const verified = jwt.verify(token, secret);
 
     // 검증된 사용자 정보를 request 객체에 저장
-    req.userid = verified;
+    req.userinfo = verified;
 
     // 다음 미들웨어로 진행
     next();

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,49 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+const userSchema = new Schema({
+  userID: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  email: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  intro: {
+    type: String,
+    default: "",
+  },
+  profileImage: {
+    type: String,
+  },
+  phoneNumber: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  links: [{ type: String }],
+  createdAt: {
+    type: Date,
+    required: true,
+    default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
+  },
+  techStack: [{ type: Schema.Types.ObjectId, ref: "TechStack" }],
+  jobGroup: {
+    type: Schema.Types.ObjectId,
+    ref: "JobGroup",
+    required: true,
+  },
+});
+
+// 1은 오름차순, -1은 내림차순 정렬을 의미합니다
+userSchema.index({ userID: 1 });
+
+const User = mongoose.model("User", userSchema);
+module.exports = User;

--- a/models/User.js
+++ b/models/User.js
@@ -31,7 +31,6 @@ const userSchema = new Schema({
   links: [{ type: String }],
   createdAt: {
     type: Date,
-    required: true,
     default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
   },
   techStack: [{ type: Schema.Types.ObjectId, ref: "TechStack" }],

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,9 +4,11 @@ const router = express.Router();
 // 라우트 파일들을 import
 const portfolioRoutes = require("./portfolioRoutes");
 const authRoutes = require("./authRoute");
+const userRoutes = require("./userRoutes");
 
 // API 라우트 설정
 router.use("/portfolios", portfolioRoutes);
 router.use("/auth", authRoutes);
+router.use("/user", userRoutes);
 
 module.exports = router;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,0 +1,4 @@
+const express = require("express");
+const router = express.Router();
+
+module.exports = router;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -14,6 +14,8 @@ router.get("/:userid", userController.getUserInfo);
 
 router.post("/", auth, userController.registerUserProfile);
 
+router.put("/", auth, userController.modifyUserProfile);
+
 module.exports = router;
 
 /**
@@ -155,4 +157,44 @@ module.exports = router;
  *                 error:
  *                   type: string
  *                   example: 유저 프로필 등록에 실패했습니다.
+ */
+
+/**
+ * @swagger
+ * /api/user:
+ *   put:
+ *     summary: 유저 프로필 수정
+ *     tags: [User]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/User'
+ *     responses:
+ *       200:
+ *         description: 유저 프로필 수정 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 유저 프로필 수정에 실패했습니다.
  */

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -7,6 +7,152 @@ const User = require("../models/User");
 //controller
 const userController = require("../controllers/userController");
 
-router.get("/user/:userid", userController.getUserInfo);
+//middleware
+const auth = require("../middleware/auth");
+
+router.get("/:userid", userController.getUserInfo);
+
+router.post("/", auth, userController.registerUserProfile);
 
 module.exports = router;
+
+/**
+ * @swagger
+ * tags:
+ *   name: User
+ *   description: 포트폴리오 관리 API
+ */
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     User:
+ *       type: object
+ *       properties:
+ *         userID:
+ *           type: string
+ *           description: 유저 아이디
+ *         name:
+ *           type: string
+ *           description: 유저 이름
+ *         email:
+ *           type: string
+ *           description: 유저 이메일
+ *         intro:
+ *           type: string
+ *           description: 유저 소개
+ *         phoneNumber:
+ *           type: string
+ *           description: 유저 휴대폰 번호
+ *         links:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: 유저 외부 링크
+ *         techStack:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: 유저 기술 스택 배열
+ *         jobGroup:
+ *           type: number
+ *           description: 유저 직무
+ *         profileImage:
+ *           type: string
+ *           description: 유저 프로필 이미지 URL
+ */
+
+/**
+ * @swagger
+ * /api/user/{userid}:
+ *   get:
+ *     summary: 유저 프로필 조회
+ *     tags: [User]
+ *     parameters:
+ *       - in: path
+ *         name: userid
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 유저 ID
+ *     responses:
+ *       200:
+ *         description: 유저 프로필 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: 잘못된 요청
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 유효하지 않은 유저 ID입니다.
+ *       404:
+ *         description: 유저를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 해당 ID의 유저를 찾을 수 없습니다.
+ */
+
+/**
+ * @swagger
+ * /api/user:
+ *   post:
+ *     summary: 유저 프로필 등록
+ *     tags: [User]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/User'
+ *     responses:
+ *       201:
+ *         description: 유저 프로필 등록 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 유저 프로필 등록에 실패했습니다.
+ */

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,4 +1,12 @@
 const express = require("express");
 const router = express.Router();
 
+//schema
+const User = require("../models/User");
+
+//controller
+const userController = require("../controllers/userController");
+
+router.get("/user/:userid", userController.getUserInfo);
+
 module.exports = router;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
User API CRUD 구현 및 Swagger 반영

## 📌 이슈 넘버
-  #13 

## 📝 작업 내용
- **유저 Schema** 구현 (Model)
userID로 인덱싱 진행
- **유저 프로필 조회** API 구현
- **유저 프로필 등록** API 구현
- **유저 프로필 수정** API 구현
userID 혹은 name ( github 데이터 ) 수정에 대한 예외처리 적용
- jwt 토큰에 **accesstoken** 추가

프로필 등록 API 구현 과정에서 유저의 깃허브 이름을 가져와야 해서 jwt에 accesstoken도 추가했습니다.
`authController.js`
```javascript
const token = jwt.sign(
      { id: userData.login, access_token: accessToken },
      secret,
      {}
    );
```
## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)
유저 프로필 정보 가져오면서 유저의 포트폴리오도 함께 가져와야 하는데, 이 부분은 나중에 모든 DB를 연결하는 과정에서 추가하도록 하겠습니다.

