### PR TITLE
[FEAT] 포트폴리오 검색 api 구현

### DIFF
--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -166,10 +166,107 @@ const deletePortfolio = async (req, res) => {
   }
 };
 
+// 포트폴리오 검색
+const searchPortfolios = async (req, res) => {
+  try {
+    const { type, keyword } = req.params;
+    const { sort = "latest" } = req.query; // 정렬 옵션: 'latest' 또는 'popular'
+
+    // 타입과 키워드 처리 - 하이픈이나 공백인 경우 빈 문자열로 처리
+    const searchType = type === "-" || type === " " ? "" : type;
+    const searchKeyword = keyword === "-" || keyword === " " ? "" : keyword;
+
+    // 검색 조건 설정
+    const matchStage = {};
+
+    // 기술 스택 검색 조건
+    if (searchType) {
+      matchStage.techStack = searchType; // 문자열 배열에서 직접 검색
+    }
+
+    // 키워드 검색 조건 (제목에서 검색, 대소문자 구분 없이)
+    if (searchKeyword) {
+      matchStage.title = new RegExp(searchKeyword, "i");
+    }
+
+    // Aggregation Pipeline 구성
+    const pipeline = [
+      { $match: matchStage },
+      {
+        // Like 컬렉션과 조인하여 좋아요 수 계산
+        $lookup: {
+          from: "likes",
+          localField: "_id",
+          foreignField: "portfolioID",
+          as: "likes",
+        },
+      },
+      {
+        // 좋아요 수를 계산하여 새로운 필드 추가
+        $addFields: {
+          likeCount: { $size: "$likes" },
+        },
+      },
+      // jobGroup 정보 조회
+      {
+        $lookup: {
+          from: "jobgroups",
+          localField: "jobGroup",
+          foreignField: "_id",
+          as: "jobGroupInfo",
+        },
+      },
+      {
+        $unwind: {
+          path: "$jobGroupInfo",
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+      // 필요한 필드만 선택
+      {
+        $project: {
+          title: 1,
+          contents: 1,
+          view: 1,
+          images: 1,
+          tags: 1,
+          techStack: 1, // 기술 스택은 문자열 배열로 직접 표시
+          createdAt: 1,
+          thumbnailImage: 1,
+          userID: 1,
+          likeCount: 1,
+          jobGroup: "$jobGroupInfo", // jobGroup 정보 매핑
+        },
+      },
+    ];
+
+    // 정렬 조건 추가
+    if (sort === "popular") {
+      pipeline.push({ $sort: { likeCount: -1, createdAt: -1 } });
+    } else {
+      pipeline.push({ $sort: { createdAt: -1 } });
+    }
+
+    const portfolios = await Portfolio.aggregate(pipeline);
+
+    res.status(200).json({
+      success: true,
+      count: portfolios.length,
+      data: portfolios,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: error.message || "포트폴리오 검색에 실패했습니다.",
+    });
+  }
+};
+
 module.exports = {
   getAllPortfolios,
   createPortfolio,
   updatePortfolio,
   deletePortfolio,
   getPortfolioById,
+  searchPortfolios,
 };

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -17,25 +17,28 @@ const portfolioSchema = new Schema(
       required: true,
       default: 0,
     },
-    images: {
-      type: [String], // 배열 형태로 본문 이미지 URL을 저장
-      required: true,
-    },
-    tags: {
-      type: [String],
-      default: [],
-    },
+    images: [{ type: String, required: true }], // 각 배열요소의 상세 컨트롤 가능
+    tags: [
+      {
+        type: String,
+        required: false,
+      },
+    ],
     createdAt: {
       type: Date,
       required: true,
       default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
     },
-    techStack: {
-      type: [String],
-      required: true,
-    },
+    techStack: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "TechStack",
+        required: true,
+      },
+    ],
     jobGroup: {
-      type: Number,
+      type: Schema.Types.ObjectId,
+      ref: "JobGroup",
       required: true,
     },
     thumbnailImage: {

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -31,8 +31,7 @@ const portfolioSchema = new Schema(
     },
     techStack: [
       {
-        type: Schema.Types.ObjectId,
-        ref: "TechStack",
+        type: String,
         required: true,
       },
     ],

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -17,6 +17,9 @@ router.delete("/:id", portfolioController.deletePortfolio);
 // GET /api/portfolios/:id
 router.get("/:id", portfolioController.getPortfolioById);
 
+// GET /api/portfolios/search/:type/:keyword
+router.get("/search/:type/:keyword", portfolioController.searchPortfolios);
+
 module.exports = router;
 
 /**
@@ -266,4 +269,133 @@ module.exports = router;
  *         description: 잘못된 요청
  *       404:
  *         description: 포트폴리오를 찾을 수 없음
+ */
+/**
+ * @swagger
+ * /api/portfolios/search/{type}/{keyword}:
+ *   get:
+ *     summary: 포트폴리오 검색 (기술 스택, 키워드 검색 및 정렬)
+ *     description: |
+ *       기술 스택과 키워드를 조합하여 포트폴리오를 검색합니다.
+ *       - 검색 조건이 없는 경우 전체 포트폴리오가 조회됩니다.
+ *       - 검색어는 영문(대소문자 구분 없음), 한글, 공백을 포함할 수 있습니다.
+ *       - 정렬은 최신순(latest) 또는 인기순(popular)으로 가능합니다.
+ *
+ *       사용 예시:
+ *       - 전체 검색: /search/-/-
+ *       - 기술 스택으로만 검색: /search/React/-
+ *       - 키워드로만 검색: /search/-/인공지능
+ *       - 기술 스택 + 키워드 검색: /search/React/AI
+ *       - 정렬 옵션 추가: /search/React/AI?sort=popular
+ *     tags: [Portfolios]
+ *     parameters:
+ *       - in: path
+ *         name: type
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: |
+ *           검색할 기술 스택 (예: React, JavaScript, Python 등)
+ *           미입력 시 "-" 입력
+ *       - in: path
+ *         name: keyword
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: |
+ *           검색 키워드 (제목에서 검색)
+ *           영문(대소문자 무관), 한글, 공백 포함 가능
+ *           미입력 시 "-" 입력
+ *       - in: query
+ *         name: sort
+ *         schema:
+ *           type: string
+ *           enum: [latest, popular]
+ *         required: false
+ *         description: |
+ *           정렬 방식 선택
+ *           - latest: 최신순 (기본값)
+ *           - popular: 인기순 (좋아요 수 기준)
+ *     responses:
+ *       200:
+ *         description: 검색 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 count:
+ *                   type: integer
+ *                   description: 검색된 포트폴리오 수
+ *                   example: 2
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       _id:
+ *                         type: string
+ *                         example: "507f1f77bcf86cd799439011"
+ *                       title:
+ *                         type: string
+ *                         example: "AI 기반 React 프로젝트"
+ *                       contents:
+ *                         type: string
+ *                         example: "프로젝트 상세 내용..."
+ *                       view:
+ *                         type: integer
+ *                         example: 150
+ *                       images:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                         example: ["image1.jpg", "image2.jpg"]
+ *                       tags:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                         example: ["AI", "웹개발"]
+ *                       techStack:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                         example: ["React", "TensorFlow"]
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *                         example: "2024-01-01T00:00:00.000Z"
+ *                       thumbnailImage:
+ *                         type: string
+ *                         example: "thumbnail.jpg"
+ *                       userID:
+ *                         type: string
+ *                         example: "user123"
+ *                       likeCount:
+ *                         type: integer
+ *                         example: 42
+ *                       jobGroup:
+ *                         type: object
+ *                         properties:
+ *                           _id:
+ *                             type: string
+ *                             example: "507f1f77bcf86cd799439012"
+ *                           name:
+ *                             type: string
+ *                             example: "프론트엔드"
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: "포트폴리오 검색에 실패했습니다."
  */


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포트폴리오 검색 api 구현 및 portfolio Schema 수정

## 📌 이슈 넘버
- #10 

## 📝 작업 내용
1. Portfolio Schema 수정
  - techStack 필드 타입을 String 배열로 변경

2. 포트폴리오 검색 기능 개선
  - 검색 조건 다양화
    - 검색어(keyword)만으로 검색 가능
    - 기술 스택(techStack)만으로 검색 가능
    - 검색어와 기술 스택 모두 사용 가능
    - 조건 없이 전체 검색 가능
    - 필터 기능(최신순, 인기순) 사용 가능. default 는 최신순.
  - 검색어 처리 개선
    - 영문 대소문자 구분 없이 검색
    - 한글 검색 지원
    - 공백 포함 검색어 지원
  - 빈 검색 조건 처리
    - 검색어 또는 기술 스택이 없는 경우 '-'로 처리하도록 구현
    - 프론트엔드에서 검색 파라미터 없을 시 '-' 로 처리하도록 필요, 관련 가이드라인 작성, 추후 프론트엔드에서 검색기능 작업 시 전달 예정
       ```js
        const searchPortfolios = async (tech = techStack, kw = keyword) => {
        try {
          setLoading(true);
          setError(null);
          
          // 빈 값은 '-'로 변환
          const searchTech = tech.trim() || '-';
          const searchKeyword = kw.trim() || '-';
          
          const response = await axios.get(
            `/api/portfolios/search/${searchTech}/${searchKeyword}?sort=${sortBy}`
          );
          
          setPortfolios(response.data.data);
        } catch (err) {
          setError('포트폴리오 검색 중 오류가 발생했습니다.');
          console.error('Search error:', err);
        } finally {
          setLoading(false);
        }
      };
      ```

## 💬리뷰 요구사항(선택)

- 프론트엔드에서 기술스택이나 키워드가 없이 보낼경우를 대비해서, '-'로 처리하도록 하였습니다. 공백이나 null로 처리하면 url에 문제가 생길 수 있다고 하여( /search// 등) '-'로 처리하였습니다.

- 승규님이 작업하신 내용을 전부 반영해서(git pull origin dev) 작업하였습니다. merge시에  `/routes/index.js`에서 일부 충돌이 일어났는데, 작성하신 라우트를 전부추가하는 코드로 반영해서 해결했습니다.

- 정렬기능(최신순 및 좋아요 순)은 일단 백엔드에서 쿼리로 구현해두었습니다.
- 좋아요 순으로 정렬하는 기능은, 포트폴리오 검색 api 안에서 일단 join하는 식으로 구현하였습니다. erd보고 어찌저찌 개발해보았는데, 이런 접근법이 맞는지 살짝 헷갈리네요..!! 이 부분 검토해주시면 감사합니다.(`/controllers/portfolioController.j`s의 `searchPortfolios()`의 Aggregation Pipeline 구성 부분)
