### PR TITLE
Feat/#17 portfolio api 인증 추가

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -37,8 +37,8 @@ const getGithubCallback = async (req, res) => {
         login: "user555",
         id: "user555",
         name: "user555",
-        avatar_url: "https://github.com/images/mock-avatar.png",
-        email: "mock@example.com",
+        // avatar_url: "https://github.com/images/mock-avatar.png",
+        // email: "mock@example.com",
       };
 
       // JWT 토큰 생성

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -23,6 +23,69 @@ const getGithubCallback = async (req, res) => {
   }
 
   try {
+    // 깃허브 로그인이 불가한 개발 환경에서는 mock 데이터 사용
+    if (process.env.NODE_ENV === "development2") {
+      // Mock GitHub OAuth token response
+      const mockTokenResponse = {
+        access_token: "mock_github_access_token_123",
+        token_type: "bearer",
+        scope: "user",
+      };
+
+      // Mock GitHub user data
+      const mockUserData = {
+        login: "user555",
+        id: "user555",
+        name: "user555",
+        avatar_url: "https://github.com/images/mock-avatar.png",
+        email: "mock@example.com",
+      };
+
+      // JWT 토큰 생성
+      const token = jwt.sign(
+        {
+          id: mockUserData.login,
+          access_token: mockTokenResponse.access_token,
+        },
+        secret,
+        {}
+      );
+
+      // Swagger 테스트를 위해 리다이렉트 대신 JSON 응답 반환
+      const referer = req.headers.referer || "";
+      const isSwaggerRequest = referer.includes("/api-docs");
+      if (isSwaggerRequest) {
+        return res
+          .status(200)
+          .cookie("token", token, {
+            httpOnly: true,
+            secure: false,
+            sameSite: "lax",
+            path: "/",
+            maxAge: 24 * 60 * 60 * 1000,
+          })
+          .json({
+            success: true,
+            message: "Mock authentication successful",
+            userData: mockUserData,
+            token,
+          });
+      }
+
+      // 일반 요청의 경우 기존과 동일하게 쿠키 설정 및 리다이렉트
+      return res
+        .status(201)
+        .cookie("token", token, {
+          httpOnly: true,
+          secure: false,
+          sameSite: "lax",
+          path: "/",
+          maxAge: 24 * 60 * 60 * 1000,
+        })
+        .redirect(frontMainURL);
+    }
+
+    // 운영 환경에서는 실제 GitHub API 호출
     //Authorization Code를 사용하여 Github Access Token 가져오기
     const tokenResponse = await fetch(
       `https://github.com/login/oauth/access_token`,

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -33,10 +33,9 @@ const portfolioSchema = new Schema(
     techStack: {
       type: [String],
       required: true,
-      ref: "TechStack", // TechStack 모델을 참조
     },
     jobGroup: {
-      type: Number,
+      type: Schema.Types.ObjectId,
       required: true,
       ref: "JobGroup", // JobGroup 모델을 참조
     },

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -33,10 +33,12 @@ const portfolioSchema = new Schema(
     techStack: {
       type: [String],
       required: true,
+      ref: "TechStack", // TechStack 모델을 참조
     },
     jobGroup: {
       type: Number,
       required: true,
+      ref: "JobGroup", // JobGroup 모델을 참조
     },
     thumbnailImage: {
       type: String,

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -30,10 +30,12 @@ const portfolioSchema = new Schema(
       required: true,
       default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
     },
-    techStack: {
-      type: [String],
-      required: true,
-    },
+    techStack: [
+      {
+        type: String,
+        required: true,
+      },
+    ],
     jobGroup: {
       type: Schema.Types.ObjectId,
       required: true,

--- a/models/User.js
+++ b/models/User.js
@@ -37,7 +37,6 @@ const userSchema = new Schema({
     {
       type: String,
       required: true,
-      ref: "TechStack",
     },
   ],
   jobGroup: {

--- a/models/User.js
+++ b/models/User.js
@@ -33,7 +33,13 @@ const userSchema = new Schema({
     type: Date,
     default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
   },
-  techStack: [{ type: Schema.Types.ObjectId, ref: "TechStack" }],
+  techStack: [
+    {
+      type: String,
+      required: true,
+      ref: "TechStack",
+    },
+  ],
   jobGroup: {
     type: Schema.Types.ObjectId,
     ref: "JobGroup",

--- a/routes/authRoute.js
+++ b/routes/authRoute.js
@@ -30,7 +30,7 @@ router.get("/github", authController.getGithubRedirectURL);
  *     - Auth
  *     summary: Github OAuth Callback API
  *     parameters:
- *      - name: id
+ *      - name: code
  *        in: query
  *        description: Github Authorization Code
  *        schema:

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -1,21 +1,16 @@
 const express = require("express");
 const router = express.Router();
 const portfolioController = require("../controllers/portfolioController.js");
+const auth = require("../middleware/auth");
 
-// GET /api/portfolios
-router.get("/", portfolioController.getAllPortfolios);
+// 전체 조회는 인증이 필요없으므로 미들웨어 적용하지 않음
+router.get("/", portfolioController.getAllPortfolios); // GET /api/portfolios
+router.get("/:id", portfolioController.getPortfolioById); // GET /api/portfolios/:id
 
-// POST /api/portfolios
-router.post("/", portfolioController.createPortfolio);
-
-// PUT /api/portfolios/:id
-router.put("/:id", portfolioController.updatePortfolio);
-
-// DELETE /api/portfolios/:id
-router.delete("/:id", portfolioController.deletePortfolio);
-
-// GET /api/portfolios/:id
-router.get("/:id", portfolioController.getPortfolioById);
+// 생성, 수정, 삭제는 인증된 사용자만 가능하도록 auth 미들웨어 적용
+router.post("/", auth, portfolioController.createPortfolio); // POST /api/portfolios
+router.put("/:id", auth, portfolioController.updatePortfolio); // PUT /api/portfolios/:id
+router.delete("/:id", auth, portfolioController.deletePortfolio); // DELETE /api/portfolios/:id
 
 module.exports = router;
 
@@ -166,7 +161,9 @@ module.exports = router;
  * @swagger
  * /api/portfolios:
  *   post:
- *     summary: 새 포트폴리오 생성
+ *     summary: 새 포트폴리오 생성 (인증 필요)
+ *     security:
+ *       - cookieAuth: []
  *     tags: [Portfolios]
  *     requestBody:
  *       required: true
@@ -187,6 +184,16 @@ module.exports = router;
  *                   example: true
  *                 data:
  *                   $ref: '#/components/schemas/Portfolio'
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 인증이 필요합니다
  *       400:
  *         description: Bad request
  *         content:
@@ -201,11 +208,14 @@ module.exports = router;
  *                   type: string
  *                   example: 포트폴리오 생성에 실패했습니다.
  */
+
 /**
  * @swagger
  * /api/portfolios/{id}:
  *   put:
- *     summary: 포트폴리오 수정
+ *     summary: 포트폴리오 수정 (인증 필요)
+ *     security:
+ *       - cookieAuth: []
  *     tags: [Portfolios]
  *     parameters:
  *       - in: path
@@ -233,13 +243,36 @@ module.exports = router;
  *                   example: true
  *                 data:
  *                   $ref: '#/components/schemas/Portfolio'
- *       400:
- *         description: 잘못된 요청
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 인증이 필요합니다
+ *       403:
+ *         description: 권한 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 포트폴리오를 수정할 권한이 없습니다.
  *       404:
  *         description: 포트폴리오를 찾을 수 없음
  *
  *   delete:
- *     summary: 포트폴리오 삭제
+ *     summary: 포트폴리오 삭제 (인증 필요)
+ *     security:
+ *       - cookieAuth: []
  *     tags: [Portfolios]
  *     parameters:
  *       - in: path
@@ -262,8 +295,29 @@ module.exports = router;
  *                 message:
  *                   type: string
  *                   example: 포트폴리오가 성공적으로 삭제되었습니다.
- *       400:
- *         description: 잘못된 요청
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 인증이 필요합니다
+ *       403:
+ *         description: 권한 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 포트폴리오를 삭제할 권한이 없습니다.
  *       404:
  *         description: 포트폴리오를 찾을 수 없음
  */

--- a/swagger/index.js
+++ b/swagger/index.js
@@ -29,7 +29,16 @@ const options = {
 
 const specs = swaggerJsdoc(options);
 
+// Swagger UI 커스텀 옵션 설정
+const swaggerUiOptions = {
+  swaggerOptions: {
+    persistAuthorization: true, // 페이지 새로고침해도 인증 상태 유지
+    withCredentials: true, // 쿠키 전송 허용
+  },
+};
+
 module.exports = {
   swaggerUi,
   specs,
+  swaggerUiOptions, // 새로 추가된 옵션 export
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
Schema 필드 타입 변경 및 api 사용자 인증 관련 기능 개선

## 📌 이슈 넘버
- #17 

## 📝 작업 내용

1. Schema 수정

- User/Portfolio Schema의 techStack 필드 타입 변경
- Portfolio Schema의 techStack, jobGroup 필드 ref 연결

2. 인증/보안 관련 개선

- 포트폴리오 CRUD API에 auth 미들웨어 추가
- 인증된 사용자의 userID를 사용하도록 로직 변경

3. Swagger UI 개선

- GitHub 콜백 API parameters 변수명 수정(`name:id`->`name:code`)
- 인증 유지 및 쿠키 전송 허용 설정
- 깃허브 로그인 기능 사용이 어려운 개발 환경(NODE_ENV=development2)에서는,  `/api/auth/github/callback` api 테스트 시 mock response data 사용

## 💬리뷰 요구사항(선택)

- auth 미들웨어 적용 범위는 조회api를 제외한 포트폴리오 생성,수정,삭제 api 이렇게 3개 적용했습니다.

- 실제로 swagger에서 사용자 인증 기반으로 api가 동작하는지 확인하고 싶어서, 특수 개발 환경((NODE_ENV=development2)에서 `/api/auth/github/callback` api 테스트 시 mock response data 사용하도록 코드를 일부 추가했습니다. 아마 승규님 개발환경(NODE_ENV=development)에서는 기존 로직대로 잘 돌아갈 것으로 예상됩니다.