### PR TITLE
[FEAT] JobGroup API 구현

### DIFF
--- a/controllers/jobGroupController.js
+++ b/controllers/jobGroupController.js
@@ -1,0 +1,19 @@
+const JobGroup = require("../models/JobGroup");
+const mongoose = require("mongoose");
+
+const createJobGroup = async (req, res) => {
+  try {
+    const { job } = req.body;
+
+    const jobGroup = await JobGroup.create({ job });
+
+    res.status(201).json({ success: true, data: jobGroup });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      error: error.message || "jobGroup 생성에 실패했습니다.",
+    });
+  }
+};
+
+module.exports = { createJobGroup };

--- a/controllers/jobGroupController.js
+++ b/controllers/jobGroupController.js
@@ -16,4 +16,20 @@ const createJobGroup = async (req, res) => {
   }
 };
 
-module.exports = { createJobGroup };
+const getAllJobGroup = async (req, res) => {
+  try {
+    const jobGroup = await JobGroup.find().sort({ job: 1 }).select("-__v");
+
+    res.status(200).json({
+      success: true,
+      data: jobGroup,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: "직무 정보를 가져오는데 실패했습니다.",
+    });
+  }
+};
+
+module.exports = { createJobGroup, getAllJobGroup };

--- a/models/JobGroup.js
+++ b/models/JobGroup.js
@@ -1,0 +1,12 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+const jobGroupSchema = new Schema({
+  job: {
+    type: String,
+    required: true,
+  },
+});
+
+const JobGroup = mongoose.model("JobGroup", jobGroupSchema);
+module.exports = JobGroup;

--- a/models/JobGroup.js
+++ b/models/JobGroup.js
@@ -5,6 +5,7 @@ const jobGroupSchema = new Schema({
   job: {
     type: String,
     required: true,
+    unique: true,
   },
 });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,11 +6,13 @@ const portfolioRoutes = require("./portfolioRoutes");
 const authRoutes = require("./authRoute");
 const techStackRoutes = require("./techStackRoute");
 const userRoutes = require("./userRoutes");
+const jobRoutes = require("./jobGroupRoute");
 
 // API 라우트 설정
 router.use("/portfolios", portfolioRoutes);
 router.use("/auth", authRoutes);
 router.use("/techstacks", techStackRoutes);
 router.use("/user", userRoutes);
+router.use("/job-group", jobRoutes);
 
 module.exports = router;

--- a/routes/jobGroupRoute.js
+++ b/routes/jobGroupRoute.js
@@ -1,0 +1,4 @@
+const express = require("express");
+const router = express.Router();
+
+module.exports = router;

--- a/routes/jobGroupRoute.js
+++ b/routes/jobGroupRoute.js
@@ -1,4 +1,7 @@
 const express = require("express");
 const router = express.Router();
+const jobGroupController = require("../controllers/jobGroupController");
+
+router.post("/", jobGroupController.createJobGroup);
 
 module.exports = router;

--- a/routes/jobGroupRoute.js
+++ b/routes/jobGroupRoute.js
@@ -6,3 +6,112 @@ router.get("/", jobGroupController.getAllJobGroup);
 router.post("/", jobGroupController.createJobGroup);
 
 module.exports = router;
+
+/**
+ * @swagger
+ * tags:
+ *   name: JobGroup
+ *   description: 직무 정보 관리 API
+ */
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     JobGroup:
+ *       type: object
+ *       required:
+ *         - _id
+ *         - job
+ *       properties:
+ *         _id:
+ *           type: string
+ *           description: 직무 코드 (id)
+ *         job:
+ *           type: string
+ *           description: 직무 이름
+ */
+/**
+ * @swagger
+ * /api/job-group:
+ *   get:
+ *     summary: 전체 직무 조회
+ *     tags: [JobGroup]
+ *     responses:
+ *       200:
+ *         description: 전체 직무 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/JobGroup'
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 직무 정보를 가져오는데 실패했습니다.
+ */
+/**
+ * @swagger
+ * /api/job-group:
+ *   post:
+ *     summary: 새로운 직무 생성
+ *     tags: [JobGroup]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               job:
+ *                 type: string
+ *                 example: Frontend
+ *     responses:
+ *       201:
+ *         description: 새로운 직무 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   allOf:
+ *                   - $ref: '#/components/schemas/JobGroup'
+ *                   - type: object
+ *                     properties:
+ *                       __v:
+ *                         type: number
+ *                         example: 0
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: jobGroup 생성에 실패했습니다.
+ */

--- a/routes/jobGroupRoute.js
+++ b/routes/jobGroupRoute.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const jobGroupController = require("../controllers/jobGroupController");
 
+router.get("/", jobGroupController.getAllJobGroup);
 router.post("/", jobGroupController.createJobGroup);
 
 module.exports = router;

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -7,15 +7,14 @@ const auth = require("../middleware/auth");
 router.get("/", portfolioController.getAllPortfolios); // GET /api/portfolios
 router.get("/:id", portfolioController.getPortfolioById); // GET /api/portfolios/:id
 
-// 생성, 수정, 삭제는 인증된 사용자만 가능하도록 auth 미들웨어 적용
+// 생성, 수정, 삭제는 인증된 사용자만 가능하도록 auth 미들웨어 적용 + 좋아요
 router.post("/", auth, portfolioController.createPortfolio); // POST /api/portfolios
 router.put("/:id", auth, portfolioController.updatePortfolio); // PUT /api/portfolios/:id
 router.delete("/:id", auth, portfolioController.deletePortfolio); // DELETE /api/portfolios/:id
+router.post("/:id/like", auth, portfolioController.toggleLike);
 
 // GET /api/portfolios/search/:type/:keyword
 router.get("/search/:type/:keyword", portfolioController.searchPortfolios);
-
-router.post("/:id/like", auth, portfolioController.toggleLike);
 
 module.exports = router;
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
JobGroup 스키마 생성 및 관련 API 구현

## 📌 이슈 넘버
- #24 

## 📝 작업 내용
1. JobGroup 스키마 생성

`JobGroup.js`
```javascript
  job: {
    type: String,
    required: true,
    unique: true,
  }
```
2. 직무 생성 API 구현

3. 모든 직무 조회 API 구현



## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)
간단하게 JobGroup CR(not UD) 구현했습니다.
