### PR TITLE
[REFACTOR] 유저 조회 api 좋아요 로직 수정 & 코드 개선

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -57,7 +57,7 @@ const getUserInfo = async (req, res) => {
     if (user.length < 1) {
       return res
         .status(404)
-        .json({ success: false, error: "사용자정보를 찾을 수 없어요" });
+        .json({ success: false, error: "해당 ID의 유저를 찾을 수 없습니다." });
     }
 
     res.json({

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -6,26 +6,66 @@ const getUserInfo = async (req, res) => {
   const { userid } = req.params;
 
   try {
-    const userDoc = await User.findOne({ userID: userid });
+    const user = await User.aggregate([
+      { $match: { userID: userid } },
+      {
+        $lookup: {
+          // 유저의 portfolio와 join
+          from: "portfolios",
+          localField: "userID",
+          foreignField: "userID",
+          as: "user_portfolios",
+          pipeline: [
+            {
+              $project: {
+                _id: 1,
+              },
+            },
+          ],
+        },
+      },
+      {
+        $lookup: {
+          // 각 유저 포트폴리오와 like join
+          from: "likes",
+          localField: "user_portfolios._id",
+          foreignField: "portfolioID",
+          as: "post_likes",
+          pipeline: [
+            {
+              $project: {
+                _id: 1,
+              },
+            },
+          ],
+        },
+      },
+      {
+        $addFields: {
+          total_like: { $size: "$post_likes" },
+        },
+      },
+      {
+        $project: {
+          user_portfolios: 0,
+          post_likes: 0,
+          __v: 0,
+        },
+      },
+    ]);
 
-    if (!userDoc) {
-      return res.status(404).json({ message: "사용자정보를 찾을 수 없어요" });
+    if (user.length < 1) {
+      return res
+        .status(404)
+        .json({ success: false, error: "사용자정보를 찾을 수 없어요" });
     }
-
-    /* 포트폴리오 가져오는 코드 추가해야 함 **/
-
-    /* 총 좋아요 수 가져오기 **/
-    const likeCount = await Like.countDocuments({ userID: userid });
 
     res.json({
       success: true,
-      data: {
-        ...userDoc.toObject(),
-        likeCount,
-      },
+      data: user[0],
     });
   } catch (err) {
-    res.status(500).json({ message: "서버에러" });
+    res.status(500).json({ success: false, error: "서버에러" });
   }
 };
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,4 +1,3 @@
-const Like = require("../models/Like");
 const User = require("../models/User");
 const mongoose = require("mongoose");
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -159,6 +159,13 @@ const getPopularUserProfile = async (req, res) => {
           localField: "userID",
           foreignField: "userID",
           as: "user_portfolios",
+          pipeline: [
+            {
+              $project: {
+                _id: 1,
+              },
+            },
+          ],
         },
       },
       {
@@ -171,6 +178,13 @@ const getPopularUserProfile = async (req, res) => {
           localField: "user_portfolios._id",
           foreignField: "portfolioID",
           as: "post_likes",
+          pipeline: [
+            {
+              $project: {
+                _id: 1,
+              },
+            },
+          ],
         },
       },
       {

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -93,22 +93,12 @@ module.exports = router;
  *                     - $ref: '#/components/schemas/User'
  *                     - type: object
  *                       properties:
- *                         likeCount:
+ *                         total_like:
  *                           type: number
  *                           example: 0
- *       400:
- *         description: 잘못된 요청
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: false
- *                 error:
- *                   type: string
- *                   example: 유효하지 않은 유저 ID입니다.
+ *                         createdAt:
+ *                           type: Date
+ *                           example: "date"
  *       404:
  *         description: 유저를 찾을 수 없음
  *         content:
@@ -122,6 +112,19 @@ module.exports = router;
  *                 error:
  *                   type: string
  *                   example: 해당 ID의 유저를 찾을 수 없습니다.
+ *       500:
+ *         description: 유저를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 서버 에러
  */
 
 /**


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 유저 조회 api 좋아요 계산 로직 수정 & 인기 유저 조회 성능 개선

## 📌 이슈 넘버
- #31 

## 📝 작업 내용
1. 유저 조회 api 좋아요 계산 로직 수정

    **기존**
    좋아요 컬렉션에서 유저 ID에 해당하는 모든 좋아요의 개수 계산 
    
    **문제점**
    유저가 누른 좋아요 개수가 아닌 유저 포트폴리오의 좋아요 개수의 합이 되어야 함
    
    **해결**
    포트폴리오와 좋아요 테이블을 join하여 유저 포트폴리오의 좋아요 합을 계산하고 필드에 추가함 

2. 인기 유저 조회 성능 개선
포트폴리오와 좋아요 테이블의 id 필드만 가져와 join 할 수 있게 변경 ( 기존에는 모든 필드를 가져왔음 )

3. 불필요한 import 삭제 및 오타 수정 진행

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
