### PR TITLE
[FEAT] Comment CRUD api 구현

### DIFF
--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -3,8 +3,41 @@ const Comment = require("../models/Comment");
 exports.getCommentsByPortfolioId = async (req, res) => {
   try {
     const { portfolioId } = req.params;
-    const comments = await Comment.find({ portfolioID: portfolioId });
-    res.json(comments);
+    const { page = 1, limit = 10 } = req.query; // 기본값: 1페이지, 15개씩
+
+    // 쿼리 파라미터는 문자열로 오기때문에, 문자열을 숫자로 변환.
+    const pageNum = parseInt(page);
+    const limitNum = parseInt(limit);
+    // 유효성 검사
+    if (pageNum < 1 || limitNum < 1) {
+      return res.status(400).json({
+        message: "페이지와 limit는 1 이상이어야 합니다.",
+      });
+    }
+
+    // 전체 댓글 수 조회
+    const totalComments = await Comment.countDocuments({
+      portfolioID: portfolioId,
+    });
+
+    // 페이지네이션 적용하여 댓글 조회
+    const comments = await Comment.find({ portfolioID: portfolioId }) // 주어진 포트폴리오 ID에 해당하는 댓글만 조회
+      .sort({ createdAt: -1 }) // 최신 댓글이 먼저 오도록 내림차순 정렬
+      .skip((pageNum - 1) * limitNum) // 불러올 댓글의 시작 지점을 설정. 해당 페이지에 해당하는 댓글만 조회하도록 함.
+      .limit(limitNum) // 한 번에 가져올 최대 댓글 수 제한
+      .exec(); // 쿼리를 실행하고 결과를 반환
+
+    // 전체 페이지 수 계산
+    const totalPages = Math.ceil(totalComments / limitNum);
+
+    res.json({
+      comments,
+      currentPage: pageNum,
+      totalPages,
+      totalComments,
+      hasNextPage: pageNum < totalPages, // 마지막 페이지인지 확인하기에 용이
+      hasPrevPage: pageNum > 1,
+    });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -1,0 +1,80 @@
+const Comment = require("../models/Comment");
+
+exports.getCommentsByPortfolioId = async (req, res) => {
+  try {
+    const { portfolioId } = req.params;
+    const comments = await Comment.find({ portfolioID: portfolioId });
+    res.json(comments);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+exports.createComment = async (req, res) => {
+  const { portfolioId } = req.params;
+  const { content } = req.body;
+  const { userinfo } = req; // 인증된 사용자 정보
+
+  const newComment = new Comment({
+    content,
+    userID: userinfo.id, // 인증된 사용자 ID 사용
+    portfolioID: portfolioId,
+  });
+
+  try {
+    const savedComment = await newComment.save();
+    res.status(201).json(savedComment);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.updateComment = async (req, res) => {
+  const { commentId } = req.params;
+  const { content } = req.body;
+  const { userinfo } = req; // 인증된 사용자 정보
+
+  try {
+    // 댓글 존재 여부 및 작성자 확인
+    const comment = await Comment.findById(commentId);
+    if (!comment) {
+      return res.status(404).json({ message: "댓글을 찾을 수 없습니다." });
+    }
+
+    // 댓글 작성자와 현재 사용자가 일치하는지 확인
+    if (comment.userID !== userinfo.id) {
+      return res.status(403).json({ message: "댓글 수정 권한이 없습니다." });
+    }
+
+    // 댓글 업데이트
+    comment.content = content;
+    const updatedComment = await comment.save();
+    res.json(updatedComment);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.deleteComment = async (req, res) => {
+  const { commentId } = req.params;
+  const { userinfo } = req; // 인증된 사용자 정보
+
+  try {
+    // 댓글 존재 여부 및 작성자 확인
+    const comment = await Comment.findById(commentId);
+    if (!comment) {
+      return res.status(404).json({ message: "댓글을 찾을 수 없습니다." });
+    }
+
+    // 댓글 작성자와 현재 사용자가 일치하는지 확인
+    if (comment.userID !== userinfo.id) {
+      return res.status(403).json({ message: "댓글 삭제 권한이 없습니다." });
+    }
+
+    // 댓글 삭제
+    await Comment.findByIdAndDelete(commentId);
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -1,0 +1,27 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+const CommentSchema = new Schema({
+  // _id : 자동생성됨
+  content: {
+    type: String,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    required: true,
+    default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
+  },
+  userID: {
+    type: String,
+    required: true,
+    ref: "User", // User 모델과 연결
+  },
+  portfolioID: {
+    type: Schema.Types.ObjectId,
+    required: true,
+    ref: "Portfolio", // Portfolio 모델과 연결
+  },
+});
+
+module.exports = mongoose.model("Comment", CommentSchema);

--- a/models/Portfolio.js
+++ b/models/Portfolio.js
@@ -1,59 +1,54 @@
 const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
-const portfolioSchema = new Schema(
-  {
-    // _id : 자동생성됨
-    title: {
-      type: String,
-      required: true,
-    },
-    contents: {
-      type: String,
-      required: true,
-    },
-    view: {
-      type: Number,
-      required: true,
-      default: 0,
-    },
-    images: [{ type: String, required: true }], // 각 배열요소의 상세 컨트롤 가능
-    tags: [
-      {
-        type: String,
-        required: false,
-      },
-    ],
-    createdAt: {
-      type: Date,
-      required: true,
-      default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
-    },
-    techStack: [
-      {
-        type: String,
-        required: true,
-      },
-    ],
-    jobGroup: {
-      type: Schema.Types.ObjectId,
-      required: true,
-      ref: "JobGroup", // JobGroup 모델을 참조
-    },
-    thumbnailImage: {
-      type: String,
-      default: null,
-    },
-    userID: {
-      type: String,
-      required: true,
-      ref: "User", // User 모델을 참조
-    },
+const portfolioSchema = new Schema({
+  // _id : 자동생성됨
+  title: {
+    type: String,
+    required: true,
   },
-  {
-    timestamps: true,
-  }
-);
+  contents: {
+    type: String,
+    required: true,
+  },
+  view: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  images: [{ type: String, required: true }], // 각 배열요소의 상세 컨트롤 가능
+  tags: [
+    {
+      type: String,
+      required: false,
+    },
+  ],
+  createdAt: {
+    type: Date,
+    required: true,
+    default: Date.now, // UTC 기준으로 저장, 조회 시 한국 시간으로 변환 필요
+  },
+  techStack: [
+    {
+      type: String,
+      required: true,
+    },
+  ],
+  jobGroup: {
+    type: Schema.Types.ObjectId,
+    required: true,
+    ref: "JobGroup", // JobGroup 모델을 참조
+  },
+  thumbnailImage: {
+    type: String,
+    default: null,
+  },
+  userID: {
+    type: String,
+    required: true,
+    ref: "User", // User 모델을 참조
+  },
+});
 
 // 1은 오름차순, -1은 내림차순 정렬을 의미합니다
 portfolioSchema.index({ userID: 1 }); // 특정 사용자의 모든 포트폴리오 검색 시 성능 향상

--- a/routes/commentRoutes.js
+++ b/routes/commentRoutes.js
@@ -1,0 +1,214 @@
+const express = require("express");
+const router = express.Router();
+const auth = require("../middleware/auth");
+const commentController = require("../controllers/commentController");
+
+router.get("/:portfolioId", commentController.getCommentsByPortfolioId); // 특정 포트폴리오의 댓글 조회
+
+router.post("/:portfolioId", auth, commentController.createComment); // 특정 포트폴리오에 댓글 생성
+
+router.put("/:commentId", auth, commentController.updateComment); // 특정 댓글 수정
+
+router.delete("/:commentId", auth, commentController.deleteComment); // 특정 댓글 삭제
+
+module.exports = router;
+
+/**
+ * @swagger
+ * tags:
+ *   name: Comment
+ *   description: 댓글 관리 API
+ *
+ * @swagger
+ * components:
+ *   schemas:
+ *     Comment:
+ *       type: object
+ *       properties:
+ *         _id:
+ *           type: string
+ *         content:
+ *           type: string
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         userID:
+ *           type: string
+ *         portfolioID:
+ *           type: string
+ *     NewComment:
+ *       type: object
+ *       required:
+ *         - content
+ *       properties:
+ *         content:
+ *           type: string
+ *     Error:
+ *       type: object
+ *       properties:
+ *         message:
+ *           type: string
+ */
+
+/**
+ * @swagger
+ * /api/comments/{portfolioId}:
+ *   get:
+ *     summary: 포트폴리오의 댓글 조회
+ *     tags: [Comment]
+ *     parameters:
+ *       - in: path
+ *         name: portfolioId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: 성공적인 응답
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Comment'
+ *
+ * @swagger
+ * /api/comments/{portfolioId}:
+ *   post:
+ *     summary: 포트폴리오의 댓글 생성
+ *     tags: [Comment]
+ *     parameters:
+ *       - in: path
+ *         name: portfolioId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/NewComment'
+ *     responses:
+ *       201:
+ *         description: 성공적인 응답
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Comment'
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *   schemas:
+ *     Comment:
+ *       type: object
+ *       properties:
+ *         _id:
+ *           type: string
+ *         content:
+ *           type: string
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         userID:
+ *           type: string
+ *         portfolioID:
+ *           type: string
+ *     NewComment:
+ *       type: object
+ *       properties:
+ *         content:
+ *           type: string
+ *     Error:
+ *       type: object
+ *       properties:
+ *         message:
+ *           type: string
+ */
+/**
+ * @swagger
+ * /api/comments/{commentId}:
+ *   put:
+ *     summary: 댓글 수정
+ *     tags: [Comment]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: commentId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 수정할 댓글의 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - content
+ *             properties:
+ *               content:
+ *                 type: string
+ *                 description: 수정할 댓글 내용
+ *     responses:
+ *       200:
+ *         description: 댓글이 성공적으로 수정됨
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Comment'
+ *       403:
+ *         description: 댓글 수정 권한 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: 댓글을 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *
+ *   delete:
+ *     summary: 댓글 삭제
+ *     tags: [Comment]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: commentId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 삭제할 댓글의 ID
+ *     responses:
+ *       204:
+ *         description: 댓글이 성공적으로 삭제됨
+ *       403:
+ *         description: 댓글 삭제 권한 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: 댓글을 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */

--- a/routes/commentRoutes.js
+++ b/routes/commentRoutes.js
@@ -18,10 +18,33 @@ module.exports = router;
  * tags:
  *   name: Comment
  *   description: 댓글 관리 API
- *
+ */
+/**
  * @swagger
  * components:
  *   schemas:
+ *     CommentResponse:
+ *       type: object
+ *       properties:
+ *         comments:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/Comment'
+ *         currentPage:
+ *           type: integer
+ *           description: 현재 페이지 번호
+ *         totalPages:
+ *           type: integer
+ *           description: 전체 페이지 수
+ *         totalComments:
+ *           type: integer
+ *           description: 전체 댓글 수
+ *         hasNextPage:
+ *           type: boolean
+ *           description: 다음 페이지 존재 여부
+ *         hasPrevPage:
+ *           type: boolean
+ *           description: 이전 페이지 존재 여부
  *     Comment:
  *       type: object
  *       properties:
@@ -54,7 +77,7 @@ module.exports = router;
  * @swagger
  * /api/comments/{portfolioId}:
  *   get:
- *     summary: 포트폴리오의 댓글 조회
+ *     summary: 포트폴리오의 댓글 조회 (페이지네이션)
  *     tags: [Comment]
  *     parameters:
  *       - in: path
@@ -62,16 +85,42 @@ module.exports = router;
  *         required: true
  *         schema:
  *           type: string
+ *         description: 포트폴리오 ID
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 10
+ *         description: 페이지당 댓글 수
  *     responses:
  *       200:
  *         description: 성공적인 응답
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Comment'
- *
+ *               $ref: '#/components/schemas/CommentResponse'
+ *       400:
+ *         description: 잘못된 요청 (페이지 번호나 limit가 유효하지 않음)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+/**
  * @swagger
  * /api/comments/{portfolioId}:
  *   post:
@@ -104,7 +153,8 @@ module.exports = router;
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Error'
- *
+ */
+/**
  * @swagger
  * components:
  *   securitySchemes:

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const authRoutes = require("./authRoute");
 const techStackRoutes = require("./techStackRoute");
 const userRoutes = require("./userRoutes");
 const jobRoutes = require("./jobGroupRoute");
+const commentRoutes = require("./commentRoutes");
 
 // API 라우트 설정
 router.use("/portfolios", portfolioRoutes);
@@ -14,5 +15,6 @@ router.use("/auth", authRoutes);
 router.use("/techstacks", techStackRoutes);
 router.use("/users", userRoutes);
 router.use("/job-group", jobRoutes);
+router.use("/comments", commentRoutes);
 
 module.exports = router;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
Comment 기능 구현 및 스키마 개선

## 📌 이슈 넘버
- #26 

## 📝 작업 내용
- Portfolio 및 Comment 스키마에서 중복되는 timestamp 필드 제거
  - createdAt이 timestamp 역할을 대체하고 있어 불필요한 필드 정리
- Comment 스키마 작성 및 구현
  - CRUD API 엔드포인트 구현
  - 댓글 조회 시 페이지네이션 기능 추가
    - 한 페이지당 댓글 수 제한(default = 10)
    - 페이지 번호 기반 조회 기능(default = 1)

## 💬 리뷰 요구사항