### PR TITLE
[FEAT] portfolio 조회/검색 api에 pagination 추가

### DIFF
--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -12,17 +12,17 @@ const getAllPortfolios = async (req, res) => {
     // 전체 포트폴리오 수 조회
     const totalCount = await Portfolio.countDocuments();
 
-    // 페이지네이션이 적용된 포트폴리오 조회
+    // 페이지네이션이 적용된 포트폴리오(약칭 포폴) 조회
     const portfolios = await Portfolio.find()
       .sort({ createdAt: -1 }) // 최신순 정렬
       .select("-__v") // __v 필드 제외
-      .skip(skip)
-      .limit(limit);
+      .skip(skip) // 불러올 포폴의 시작 지점을 설정. 해당 페이지에 해당하는 포폴만 조회하도록 함.
+      .limit(limit); // 한 번에 가져올 최대 포폴 수 제한
 
     /*
      * 추가적인 DetailData 삽입
      * 일단 likeCount만 추가
-     * CommentCount 추가 해야함
+     * 조회수 추가 해야함
      **/
     const portfoliosWithDetails = await Promise.all(
       portfolios.map(async (portfolio) => {

--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -6,7 +6,7 @@ const mongoose = require("mongoose");
 const getAllPortfolios = async (req, res) => {
   try {
     const page = parseInt(req.query.page, 10) || 1; // 기본값 1
-    const limit = parseInt(req.query.limit, 15) || 15; // 기본값 15
+    const limit = parseInt(req.query.limit, 10) || 15; // 기본값 15
     const skip = (page - 1) * limit;
 
     // 전체 포트폴리오 수 조회

--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -5,9 +5,19 @@ const mongoose = require("mongoose");
 // 포트폴리오 목록 조회
 const getAllPortfolios = async (req, res) => {
   try {
+    const page = parseInt(req.query.page, 10) || 1; // 기본값 1
+    const limit = parseInt(req.query.limit, 15) || 15; // 기본값 15
+    const skip = (page - 1) * limit;
+
+    // 전체 포트폴리오 수 조회
+    const totalCount = await Portfolio.countDocuments();
+
+    // 페이지네이션이 적용된 포트폴리오 조회
     const portfolios = await Portfolio.find()
       .sort({ createdAt: -1 }) // 최신순 정렬
-      .select("-__v"); // __v 필드 제외하고 클라이언트에 보여줌
+      .select("-__v") // __v 필드 제외
+      .skip(skip)
+      .limit(limit);
 
     /*
      * 추가적인 DetailData 삽입
@@ -26,9 +36,21 @@ const getAllPortfolios = async (req, res) => {
       })
     );
 
+    // 페이지네이션 메타데이터 계산
+    const totalPages = Math.ceil(totalCount / limit);
+    const hasNextPage = page < totalPages;
+    const hasPrevPage = page > 1;
+
     res.status(200).json({
       success: true,
-      count: portfolios.length,
+      pagination: {
+        currentPage: page,
+        totalPages,
+        totalCount,
+        hasNextPage,
+        hasPrevPage,
+        limit,
+      },
       data: portfoliosWithDetails,
     });
   } catch (error) {

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -391,12 +391,13 @@ module.exports = router;
  * @swagger
  * /api/portfolios/search/{type}/{keyword}:
  *   get:
- *     summary: 포트폴리오 검색 (기술 스택, 키워드 검색 및 정렬)
+ *     summary: 포트폴리오 검색 (기술 스택, 키워드 검색 및 정렬, 페이지네이션)
  *     description: |
  *       기술 스택과 키워드를 조합하여 포트폴리오를 검색합니다.
  *       - 검색 조건이 없는 경우 전체 포트폴리오가 조회됩니다.
  *       - 검색어는 영문(대소문자 구분 없음), 한글, 공백을 포함할 수 있습니다.
  *       - 정렬은 최신순(latest) 또는 인기순(popular)으로 가능합니다.
+ *       - 페이지네이션이 적용되어 있습니다.
  *
  *       사용 예시:
  *       - 전체 검색: /search/-/-
@@ -404,6 +405,7 @@ module.exports = router;
  *       - 키워드로만 검색: /search/-/인공지능
  *       - 기술 스택 + 키워드 검색: /search/React/AI
  *       - 정렬 옵션 추가: /search/React/AI?sort=popular
+ *       - 페이지네이션: /search/React/AI?page=2&limit=10
  *     tags: [Portfolios]
  *     parameters:
  *       - in: path
@@ -433,6 +435,21 @@ module.exports = router;
  *           정렬 방식 선택
  *           - latest: 최신순 (기본값)
  *           - popular: 인기순 (좋아요 수 기준)
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 조회할 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 15
+ *         description: 한 페이지당 포트폴리오 수
  *     responses:
  *       200:
  *         description: 검색 성공
@@ -444,10 +461,27 @@ module.exports = router;
  *                 success:
  *                   type: boolean
  *                   example: true
- *                 count:
- *                   type: integer
- *                   description: 검색된 포트폴리오 수
- *                   example: 2
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     currentPage:
+ *                       type: integer
+ *                       example: 1
+ *                     totalPages:
+ *                       type: integer
+ *                       example: 5
+ *                     totalCount:
+ *                       type: integer
+ *                       example: 42
+ *                     hasNextPage:
+ *                       type: boolean
+ *                       example: true
+ *                     hasPrevPage:
+ *                       type: boolean
+ *                       example: false
+ *                     limit:
+ *                       type: integer
+ *                       example: 15
  *                 data:
  *                   type: array
  *                   items:

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -85,8 +85,24 @@ module.exports = router;
  * @swagger
  * /api/portfolios:
  *   get:
- *     summary: 전체 포트폴리오 조회
+ *     summary: 전체 포트폴리오 조회 (페이지네이션)
  *     tags: [Portfolios]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 조회할 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 15
+ *         description: 한 페이지당 포트폴리오 수
  *     responses:
  *       200:
  *         description: 포트폴리오 목록 조회 성공
@@ -98,19 +114,37 @@ module.exports = router;
  *                 success:
  *                   type: boolean
  *                   example: true
- *                 count:
- *                   type: number
- *                   description: 전체 포트폴리오 수
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     currentPage:
+ *                       type: integer
+ *                       example: 1
+ *                     totalPages:
+ *                       type: integer
+ *                       example: 5
+ *                     totalCount:
+ *                       type: integer
+ *                       example: 42
+ *                     hasNextPage:
+ *                       type: boolean
+ *                       example: true
+ *                     hasPrevPage:
+ *                       type: boolean
+ *                       example: false
+ *                     limit:
+ *                       type: integer
+ *                       example: 10
  *                 data:
  *                   type: array
  *                   items:
  *                     allOf:
- *                     - $ref: '#/components/schemas/Portfolio'
- *                     - type: object
- *                       properties:
- *                         likeCount:
- *                           type: number
- *                           example: 0
+ *                       - $ref: '#/components/schemas/Portfolio'
+ *                       - type: object
+ *                         properties:
+ *                           likeCount:
+ *                             type: number
+ *                             example: 0
  *       500:
  *         description: 서버 에러
  *         content:


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
portfolio 조회/검색 api에 pagination 추가

## 📌 이슈 넘버
- #35 

## 📝 작업 내용

- portfolio 조회/검색 api에 pagination 추가
- 댓글 조회 api, 포트폴리오 조회 api, 포트폴리오 검색 api -> 3곳의 api에서 pagination 코드 및 response body 일관성있게 작성, 리팩토링

