### PR TITLE
[FEAT] 유저 포트폴리오 조회 api 구현

### DIFF
--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -426,7 +426,6 @@ const getUserPortfolios = async (req, res) => {
 
     // 해당 유저가 생성한 포트폴리오 수 조회
     const totalCount = await Portfolio.countDocuments({ userID: userid });
-    console.log("totalCount:", totalCount);
 
     // Like와 join하여 해당 포트폴리오의 좋아요 수 계산
     const pipeline = [

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -29,6 +29,9 @@ router.post("/:id/like", auth, portfolioController.toggleLike);
 // GET /api/portfolios/search/:type/:keyword
 router.get("/search/:type/:keyword", portfolioController.searchPortfolios);
 
+// GET /api/portfolios/user/:userid
+router.get("/user/:userid", portfolioController.getUserPortfolios);
+
 module.exports = router;
 
 /**
@@ -614,4 +617,82 @@ module.exports = router;
  *         description: 인증 실패
  *       500:
  *         description: 서버 에러
+ */
+/**
+ * @swagger
+ * /api/portfolios/user/{userid}:
+ *   get:
+ *     summary: 특정 사용자의 포트폴리오 목록 조회
+ *     tags: [Portfolios]
+ *     parameters:
+ *       - in: path
+ *         name: userid
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 포트폴리오 소유자 ID
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 조회할 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 15
+ *         description: 한 페이지당 포트폴리오 수
+ *     responses:
+ *       200:
+ *         description: 사용자 포트폴리오 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     currentPage:
+ *                       type: integer
+ *                       example: 1
+ *                     totalPages:
+ *                       type: integer
+ *                       example: 5
+ *                     totalCount:
+ *                       type: integer
+ *                       example: 42
+ *                     hasNextPage:
+ *                       type: boolean
+ *                       example: true
+ *                     hasPrevPage:
+ *                       type: boolean
+ *                       example: false
+ *                     limit:
+ *                       type: integer
+ *                       example: 15
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Portfolio'
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 사용자 포트폴리오 목록 조회에 실패했습니다.
  */


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
유저가 만든 포트폴리오를 전체 조회할 수 있는 api 구현

## 📌 이슈 넘버
- #37 

## 📝 작업 내용
- 포트폴리오 목록은 createdAt 기준 내림차순 정렬(최신순)
- 페이지네이션 기능 추가
- Like 테이블과 join 하여 포트폴리오별 좋아요 수 계산 기능 추가

## 💬리뷰 요구사항(선택)
pipeline 구성시에 자꾸 500에러가 나서, 해결하다가 알게된 사실 공유드립니다!
(멍청비용 날렸네요^^..)

MongoDB에서는 쿼리에서 16진수 24자리 문자 사용하면 변환 필요없이 자동으로 ObjectId로 취급하기 때문에, 
pipeline의$match단계에서 ObjectId로의 별도의 변환(moongoose.Types.ObjectId) 없이도 $match 단계에서 바로 쿼리의 userid를 사용할 수 있다네요!

이미 알고 계신 사실일 수 있지만, 혹시몰라 공유드립니다!..
