### PR TITLE
[FEAT] 유저가 좋아요 누른 포트폴리오 조회 api 구현

### DIFF
--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -274,7 +274,7 @@ const toggleLike = async (req, res) => {
   const { id: userID } = req.userinfo;
 
   try {
-    const likeCount = (await Like.find({ portfolioID })).length;
+    const likeCount = await Like.countDocuments({ portfolioID });
     const like = await Like.findOne({ portfolioID, userID });
 
     //좋아요 없는 경우 => 좋아요 생성

--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -532,6 +532,104 @@ const getUserPortfolios = async (req, res) => {
   }
 };
 
+const getUserLikePortfolios = async (req, res) => {
+  try {
+    const { userid } = req.params;
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = parseInt(req.query.limit, 10) || 15;
+    const skip = (page - 1) * limit;
+
+    const pipeline = [
+      {
+        $match: {
+          userID: userid,
+        },
+      },
+      {
+        $lookup: {
+          from: "portfolios",
+          localField: "portfolioID",
+          foreignField: "_id",
+          as: "portfolios",
+        },
+      },
+      {
+        $unwind: {
+          path: "$portfolios",
+        },
+      },
+      {
+        $project: {
+          portfolioID: 0,
+          userID: 0,
+          _id: 0,
+        },
+      },
+      {
+        $replaceRoot: {
+          // 조인한 필드를 상위로 올려서 개별 필드로 만듦
+          newRoot: { $mergeObjects: ["$portfolios", "$$ROOT"] },
+        },
+      },
+      {
+        $project: {
+          portfolios: 0,
+          __v: 0,
+        },
+      },
+      {
+        $lookup: {
+          from: "likes",
+          localField: "_id",
+          foreignField: "portfolioID",
+          as: "likes",
+        },
+      },
+      {
+        $addFields: {
+          like_count: {
+            $size: "$likes",
+          },
+        },
+      },
+      {
+        $project: {
+          likes: 0,
+        },
+      },
+      { $sort: { createdAt: -1 } },
+      { $skip: skip },
+      { $limit: limit },
+    ];
+
+    const portfolios = await Like.aggregate(pipeline);
+
+    // 페이지네이션 메타데이터 계산
+    const totalCount = await Like.countDocuments({ userID: userid });
+    const totalPages = Math.ceil(totalCount / limit);
+    const hasNextPage = page < totalPages;
+    const hasPrevPage = page > 1;
+
+    return res.status(200).json({
+      success: true,
+      pagination: {
+        currentPage: page,
+        totalPages,
+        totalCount,
+        hasNextPage,
+        hasPrevPage,
+        limit,
+      },
+      data: portfolios,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: "유저의 좋아요한 포트폴리오를 가져오지 못했습니다.",
+    });
+  }
+};
+
 module.exports = {
   getAllPortfolios,
   createPortfolio,
@@ -543,4 +641,5 @@ module.exports = {
   uploadSingleImage,
   uploadMultipleImages,
   getUserPortfolios,
+  getUserLikePortfolios,
 };

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -562,6 +562,13 @@ module.exports = router;
  *   post:
  *     summary: 포트폴리오 좋아요 (토글)
  *     tags: [Portfolios]
+ *     parameters:
+ *       - in: path
+ *         name: portfolioID
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 포트폴리오 ID
  *     responses:
  *       201:
  *         description: 포트폴리오 좋아요 성공

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -767,3 +767,82 @@ module.exports = router;
  *                   type: string
  *                   example: 사용자 포트폴리오 목록 조회에 실패했습니다.
  */
+
+/**
+ * @swagger
+ * /api/portfolios/like/{userid}:
+ *   get:
+ *     summary: 특정 사용자가 좋아요한 포트폴리오 목록 조회
+ *     tags: [Portfolios]
+ *     parameters:
+ *       - in: path
+ *         name: userid
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 포트폴리오 소유자 ID
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: 조회할 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 15
+ *         description: 한 페이지당 포트폴리오 수
+ *     responses:
+ *       200:
+ *         description: 사용자 포트폴리오 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     currentPage:
+ *                       type: integer
+ *                       example: 1
+ *                     totalPages:
+ *                       type: integer
+ *                       example: 5
+ *                     totalCount:
+ *                       type: integer
+ *                       example: 42
+ *                     hasNextPage:
+ *                       type: boolean
+ *                       example: true
+ *                     hasPrevPage:
+ *                       type: boolean
+ *                       example: false
+ *                     limit:
+ *                       type: integer
+ *                       example: 15
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Portfolio'
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 사용자 포트폴리오 목록 조회에 실패했습니다.
+ */

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -32,6 +32,9 @@ router.get("/search/:type/:keyword", portfolioController.searchPortfolios);
 // GET /api/portfolios/user/:userid
 router.get("/user/:userid", portfolioController.getUserPortfolios);
 
+// GET /api/portfolios/like/:userid
+router.get("/like/:userid", portfolioController.getUserLikePortfolios);
+
 module.exports = router;
 
 /**

--- a/routes/portfolioRoutes.js
+++ b/routes/portfolioRoutes.js
@@ -564,7 +564,7 @@ module.exports = router;
  *     tags: [Portfolios]
  *     parameters:
  *       - in: path
- *         name: portfolioID
+ *         name: id
  *         required: true
  *         schema:
  *           type: string


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
유저가 좋아요 누른 포트폴리오 조회 api 구현

## 📌 이슈 넘버
- #38 
## 📝 작업 내용
1. 유저가 좋아요 누른 포트폴리오 조회 api 구현 (**`/api/portfolios/like/:userid`**)
- 
2. 포트폴리오 좋아요 API 코드 개선
- countDocument를 사용하여 likeCount 계산
- Swagger id 파라미터 추가

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)
포트폴리오 검색/조회 API와 동일하게 ResponseBody를 구성했습니다.
