### PR TITLE
[FEAT] 포트폴리오 조회수 기능

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -146,7 +146,6 @@ const logout = (req, res) => {
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
     path: "/",
-    // expires: new Date(0),
   });
   res.json("로그아웃 되었습니다.");
 };

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -146,7 +146,7 @@ const logout = (req, res) => {
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
     path: "/",
-    expires: new Date(0),
+    // expires: new Date(0),
   });
   res.json("로그아웃 되었습니다.");
 };

--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -1,3 +1,4 @@
+const { incrementViewCount } = require("../utils/viewCounter");
 const Like = require("../models/Like");
 const Portfolio = require("../models/Portfolio");
 const mongoose = require("mongoose");
@@ -63,6 +64,8 @@ const getAllPortfolios = async (req, res) => {
 
 // 포트폴리오 상세 조회
 const getPortfolioById = async (req, res) => {
+  const session = await mongoose.startSession();
+  session.startTransaction();
   try {
     const { id } = req.params;
 
@@ -74,9 +77,16 @@ const getPortfolioById = async (req, res) => {
       });
     }
 
-    const portfolio = await Portfolio.findById(id).select("-__v");
+    // req.session이 없는 경우 (비로그인 사용자) 임시 세션 생성
+    const userSession = req.session || {
+      viewedPortfolios: {},
+      id: req.ip, // IP를 세션 ID로 사용
+    };
+
+    const portfolio = await incrementViewCount(id, userSession, session);
 
     if (!portfolio) {
+      await session.abortTransaction();
       return res.status(404).json({
         success: false,
         error: "해당 ID의 포트폴리오를 찾을 수 없습니다.",
@@ -98,6 +108,8 @@ const getPortfolioById = async (req, res) => {
       }
     }
 
+    await session.commitTransaction();
+
     res.status(200).json({
       success: true,
       data: {
@@ -107,10 +119,13 @@ const getPortfolioById = async (req, res) => {
       },
     });
   } catch (error) {
+    await session.abortTransaction();
     res.status(400).json({
       success: false,
       error: error.message || "포트폴리오 조회에 실패했습니다.",
     });
+  } finally {
+    session.endSession();
   }
 };
 

--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -77,7 +77,7 @@ const getPortfolioById = async (req, res) => {
       });
     }
 
-    // req.session이 없는 경우 (비로그인 사용자) 임시 세션 생성
+    // 사용자의 req.session이 없는 경우 임시 세션 생성
     const userSession = req.session || {
       viewedPortfolios: {},
       id: req.ip, // IP를 세션 ID로 사용

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const express = require("express");
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const mongoose = require("mongoose");
+const MongoStore = require("connect-mongo");
+const session = require("express-session");
 
 const app = express();
 const port = process.env.PORT || 8000;
@@ -40,6 +42,22 @@ app.use(
 app.use(express.json()); // JSON 파싱
 app.use(cookieParser()); // 쿠키 파싱
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs)); // Swagger UI를 /api-docs 경로에 라우팅
+
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: true,
+    store: MongoStore.create({
+      mongoUrl: process.env.MONGO_URI,
+      ttl: 24 * 60 * 60, // 세션 유효기간 1일
+    }),
+    cookie: {
+      secure: process.env.NODE_ENV === "production", // HTTPS (보안 연결)에서만 쿠키가 전송됨
+      maxAge: 24 * 60 * 60 * 1000, // 24시간
+    },
+  })
+);
 
 // 기본 라우트 설정
 app.get("/", (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.679.0",
         "bcryptjs": "^2.4.3",
+        "connect-mongo": "^5.1.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
+        "express-session": "^1.18.1",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.10.0",
         "mongoose": "^8.7.2",
@@ -1818,6 +1820,18 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1861,6 +1875,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -2047,6 +2067,23 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connect-mongo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "kruptein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
       }
     },
     "node_modules/content-disposition": {
@@ -2313,6 +2350,55 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -2757,6 +2843,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/kruptein": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.7.tgz",
+      "integrity": "sha512-vTftnEjfbqFHLqxDUMQCj6gBo5lKqjV4f0JsM8rk8rM3xmvFZ2eSy4YALdaye7E+cDKnEj7eAjFR3vwh8a4PgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">8"
+      }
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -2882,6 +2980,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3182,6 +3286,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3302,6 +3415,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3745,6 +3867,18 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.679.0",
     "bcryptjs": "^2.4.3",
+    "connect-mongo": "^5.1.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "express-session": "^1.18.1",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.10.0",
     "mongoose": "^8.7.2",

--- a/utils/viewCounter.js
+++ b/utils/viewCounter.js
@@ -1,0 +1,59 @@
+const mongoose = require("mongoose");
+const Portfolio = require("../models/Portfolio");
+
+/**
+ * 포트폴리오 조회수 증가 함수 파라미터 설명
+ * @param {string} portfolioId - 포트폴리오 ID
+ * @param {Object} session - 사용자 세션 객체
+ * @param {Object} mongoSession - MongoDB 세션 객체 (트랜잭션용)
+ * @returns {Promise<Object>} 업데이트된 포트폴리오 객체
+ */
+const incrementViewCount = async (
+  portfolioId,
+  session,
+  mongoSession = null
+) => {
+  try {
+    // 세션에서 조회 기록 확인
+    if (!session.viewedPortfolios) {
+      session.viewedPortfolios = {};
+    }
+
+    // 현재 시간과 마지막 조회 시간을 비교 (24시간 기준)
+    const lastViewTime = session.viewedPortfolios[portfolioId];
+    const currentTime = Date.now();
+    const ONE_DAY = 24 * 60 * 60 * 1000; // 24시간을 밀리초로 표현
+
+    // 해당 포트폴리오를 처음 보거나, 마지막 조회로부터 24시간이 지났다면
+    if (!lastViewTime || currentTime - lastViewTime > ONE_DAY) {
+      const updateOptions = mongoSession ? { session: mongoSession } : {};
+
+      // 조회수 증가
+      const updatedPortfolio = await Portfolio.findByIdAndUpdate(
+        portfolioId,
+        { $inc: { view: 1 } },
+        { ...updateOptions, new: true }
+      );
+
+      if (!updatedPortfolio) {
+        throw new Error("포트폴리오를 찾을 수 없습니다.");
+      }
+
+      // 세션에 현재 시간 기록
+      session.viewedPortfolios[portfolioId] = currentTime;
+
+      return updatedPortfolio;
+    }
+
+    // 중복 조회인 경우 포트폴리오 정보만 반환
+    return await Portfolio.findById(
+      portfolioId,
+      null,
+      mongoSession ? { session: mongoSession } : {}
+    );
+  } catch (error) {
+    throw error;
+  }
+};
+
+module.exports = { incrementViewCount };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포트폴리오 상세 페이지 - 조회수 기능 개선 및 트랜잭션 도입

## 📌 이슈 넘버
- #41 

## 📝 작업 내용

### 1. 문제 상황과 해결 방안
#### 기존 문제점
구현하면서 다양한 환경으로 테스트해보다가, 아래와 같은 문제점들을 마주쳤었습니다.
1. **메모리 기반 세션 저장의 한계**
   - 서버 재시작 시 모든 세션 정보가 초기화됨
   - 초기화되면, 비로그인 사용자의 조회 기록이 유실되어 조회수 중복 카운트 발생
   - 실제 서비스(Production) 환경에서 신뢰성 있는 조회수 데이터 확보 불가

2. **사용자 식별의 어려움**
   - 로그인/비로그인 상태 전환 시 동일 사용자 추적 불가

#### 해결 방안과 적용 기술
1. **MongoDB 기반 세션 스토어 도입** 
   - 서버 재시작해도 세션 정보 유지
   - `connect-mongo` 라이브러리 도입
   ```js
   // 세션 스토어 설정 예시
   app.use(
      session({
        secret: process.env.SESSION_SECRET,
        resave: false,
        saveUninitialized: true,
        store: MongoStore.create({ // 세션 스토어 도입
          mongoUrl: process.env.MONGO_URI,
          ttl: 24 * 60 * 60, // 세션 유효기간 1일
        }),
        cookie: {
          secure: process.env.NODE_ENV === "production", // HTTPS (보안 연결)에서만 쿠키가 전송됨
          maxAge: 24 * 60 * 60 * 1000, // 24시간
        },
      })
    );
   ```

2. **사용자 식별 체계 개선**
   ```javascript
   // 포트폴리오 상세 조회 api
   // req.session이 없는 경우 임시 세션 생성
   const userSession = req.session || {
     viewedPortfolios: {},
     id: req.ip, // IP 기반 세션 ID
   };
   ```
   - 비로그인 사용자도 IP 기반으로 고유 식별
   - 로그인 상태 변경과 무관하게 일관된 조회수 처리

### 2. 핵심 기능 구현
#### 조회수 중복 방지 로직 (viewCounter.js)
Portfolio 스키마에 조회수(view) 필드를 반영할때 ,중복 반영되지 않도록 하였습니다.
```javascript
const incrementViewCount = async (portfolioId, session, mongoSession = null) => {
  // 1. 세션에 조회 기록이 없으면 초기화
  if (!session.viewedPortfolios) {
    session.viewedPortfolios = {};
  }

  // 2. 마지막 조회 시간 확인
  const lastViewTime = session.viewedPortfolios[portfolioId];
  const currentTime = Date.now();
  const ONE_DAY = 24 * 60 * 60 * 1000;

  // 3. 24시간 이내 조회 여부 확인
  // 해당 포트폴리오를 처음 보거나, 마지막 조회로부터 24시간이 지났다면
  if (!lastViewTime || currentTime - lastViewTime > ONE_DAY) {
    // 4. 조회수 증가 및 시간 기록
    const updatedPortfolio = await Portfolio.findByIdAndUpdate(
      portfolioId,
      { $inc: { view: 1 } },
      { ...updateOptions, new: true }
    );
    session.viewedPortfolios[portfolioId] = currentTime;
    return updatedPortfolio;
  }
};
```

#### 트랜잭션 처리 로직
```javascript
// 1. 트랜잭션 세션 시작
const session = await mongoose.startSession();
session.startTransaction();

try {
  // 2. 포트폴리오 ID 유효성 검사
  if (!mongoose.Types.ObjectId.isValid(id)) {
    throw new Error("유효하지 않은 포트폴리오 ID입니다.");
  }

  // 3. 사용자 세션 확인 및 생성
  const userSession = req.session || {
    viewedPortfolios: {},
    id: req.ip,  // 비로그인 사용자용 임시 식별자
  };

  // 4. 조회수 증가 처리
  const portfolio = await incrementViewCount(id, userSession, session);
  
  // 5. 포트폴리오 존재 여부 확인
  if (!portfolio) {
    throw new Error("해당 ID의 포트폴리오를 찾을 수 없습니다.");
  }

  // 6. 좋아요 정보 조회
  const portfolioLikes = await Like.find({ portfolioID: id });
  
  // 7. 트랜잭션 커밋 - 모든 작업이 성공적으로 완료됨
  await session.commitTransaction();
  
} catch (error) {
  // 8. 에러 발생 시 트랜잭션 롤백
  await session.abortTransaction();
  throw error;
  
} finally {
  // 9. 트랜잭션 세션 종료
  session.endSession();
}
```

### 3. 트랜잭션 도입 이유
이번에 조회수 기능을 구현하면서, 조회수 증가 과정에서 에러가 발생할 경우 이미 증가된 조회수를 어떻게 처리할지 고민하게 되었습니다. 이 과정에서 **트랜잭션(Transaction)** 이라는 개념을 처음 알게 되었고, 이를 도입해보았습니다.

트랜잭션은 데이터베이스 작업을 원자성(Atomicity) 있게 처리하여, 모든 작업이 성공할 때만 변경이 반영되고, 중간에 문제가 발생하면 전체 작업을 취소(롤백)할 수 있는 메커니즘입니다. 이를 통해 조회수 증가 도중 에러가 발생하더라도 잘못된 데이터가 남지 않도록 할 수 있습니다.

개인 노션으로 트랜잭션에 대해 정리한 내용을 공유드립니다.
https://neighborly-gravity-69b.notion.site/12f9beca6f2e80869527fc9f06776ecb?pvs=4

### 4. 주요 변경사항
- `express-session`: 세션 관리 기본 기능 제공
- `connect-mongo`: MongoDB 세션 스토어 구현
- `res.clearCookie` 함수 옵션 수정
  ```javascript
  // Before
  res.clearCookie('connect.sid', { expires: new Date(0) });
  
  // After
  res.clearCookie('connect.sid');
  //  { expires: new Date(0) }삭제, deprecated 경고 해결
  // Express 5.0에서는 자동으로 즉시 만료 처리
  ```

## 💬 리뷰 요구사항
1. 트랜잭션 범위가 적절한지 검토 해주시면 감사합니다.
   - 현재 조회수 증가와 포트폴리오 조회를 하나의 트랜잭션으로 처리하였습니다.
   - 트랜잭션 범위를 좋아요 정보 조회까지 포함해두긴했는데 포함하는 것이 적절한지 검토해주시면 감사합니다!

2. IP 기반 세션 식별 방식의 보안 이슈
   - 현재는 req.ip를 직접 사용중입니다.
   - 더 안전한 식별 방식으로 도입해야할지, 걱정이 조금 되네요.!.. 공용 WiFi 같은 경우 ip가 동일하니까 동일 사용자로 조회될거같아요... 일단 ip방식이 간단해서 ip방식으로 판별해두긴 했는데 시간되면 리팩토링해볼까요?
  
### 테스트 시나리오
제가 swagger에서 포트폴리오 상세 조회 api 사용 시 사용했던 테스트 시나리오 몇 개를 정리하였습니다.
1. **기본 조회수 증가 테스트**
   - 포트폴리오 상세 조회(api) 최초 이용 = 페이지 최초 접속
   - 24시간 이내 재접속
   - 예상 결과: 최초 접속시에만 조회수 증가

2. **세션 유지 테스트**
   - 서버 재시작 후 동일 사용자 재접속
   - 예상 결과: 24시간 이내면 조회수 미증가

4. **사용자 상태 전환 테스트**
   - 비로그인 상태로 포트폴리오 조회
   - 로그인 후 동일 포트폴리오 조회
   - 예상 결과: 동일 세션으로 인식되어 조회수 미증가
   
현재에는 어떤 상태로 조회하던지간에 동일사용자(개발자인 본인)로 처리되어서 조회수가 1밖에 증가하는 것만 확인됩니다.
만약에 다른 사용자로 로그인해서 조회수가 더 카운팅되는 테스트를 할려면, 개발자도구(F12) > 애플리케이션 > 쿠키(localhost 8000) -> connect.sid 삭제 후 포트폴리오 상세조회 다시하면 조회수가 추가되어 카운트되는걸 보실 수 있습니다.