### PR TITLE
♻️ 중복 조회수 방지 로직 변경

### DIFF
--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -1,5 +1,4 @@
 const { incrementViewCount } = require("../utils/viewCounter");
-const { generateBrowserFingerprint } = require("../utils/browserFingerprint");
 const Like = require("../models/Like");
 const Portfolio = require("../models/Portfolio");
 const mongoose = require("mongoose");

--- a/controllers/portfolioController.js
+++ b/controllers/portfolioController.js
@@ -1,4 +1,5 @@
 const { incrementViewCount } = require("../utils/viewCounter");
+const { generateBrowserFingerprint } = require("../utils/browserFingerprint");
 const Like = require("../models/Like");
 const Portfolio = require("../models/Portfolio");
 const mongoose = require("mongoose");
@@ -77,11 +78,8 @@ const getPortfolioById = async (req, res) => {
       });
     }
 
-    // 사용자의 req.session이 없는 경우 임시 세션 생성
-    const userSession = req.session || {
-      viewedPortfolios: {},
-      id: req.ip, // IP를 세션 ID로 사용
-    };
+    // express-session은 이미 자동으로 고유한 세션 ID를 생성함. 공공 wifi 등에서도 사용자 식별 가능
+    const userSession = req.session || { viewedPortfolios: {} };
 
     const portfolio = await incrementViewCount(id, userSession, session);
 

--- a/utils/viewCounter.js
+++ b/utils/viewCounter.js
@@ -2,7 +2,7 @@ const mongoose = require("mongoose");
 const Portfolio = require("../models/Portfolio");
 
 /**
- * 포트폴리오 조회수 증가 함수 파라미터 설명
+ * 포트폴리오 조회수 증가 함수
  * @param {string} portfolioId - 포트폴리오 ID
  * @param {Object} session - 사용자 세션 객체
  * @param {Object} mongoSession - MongoDB 세션 객체 (트랜잭션용)
@@ -19,8 +19,9 @@ const incrementViewCount = async (
       session.viewedPortfolios = {};
     }
 
+    const viewKey = portfolioId;
     // 현재 시간과 마지막 조회 시간을 비교 (24시간 기준)
-    const lastViewTime = session.viewedPortfolios[portfolioId];
+    const lastViewTime = session.viewedPortfolios[viewKey];
     const currentTime = Date.now();
     const ONE_DAY = 24 * 60 * 60 * 1000; // 24시간을 밀리초로 표현
 
@@ -40,8 +41,7 @@ const incrementViewCount = async (
       }
 
       // 세션에 현재 시간 기록
-      session.viewedPortfolios[portfolioId] = currentTime;
-
+      session.viewedPortfolios[viewKey] = currentTime;
       return updatedPortfolio;
     }
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
조회수 중복 카운트 방지 로직 리팩토링

## 📌 이슈 넘버
- #41 

## 결론
express-session은 각 브라우저(기기)별로 이미 자동으로 고유한 세션 ID를 생성해주기 때문에, ip기반이나 fingerprint처럼 별도의 추가장치 없이도 사용자 식별이 가능하다. (공공 wifi인 경우에도 사용자 식별이 가능)

이전 코드처럼 ip를 세션id로 사용해버리면, 같은 공공 WiFi의 모든 사용자가 동일한 IP를 가지기 때문에 모든 사용자의 조회수가 하나로 통합되어버린다.(고유 세션 id 대신 동일한 ip가 부여되는 안좋은 효과)

## 📝 작업 내용

1. 조회수 중복 카운트 방지 로직 구현
    -   세션을 통한 사용자 식별로 공공 WiFi 등 다양한 환경에서도 정확한 조회수 집계 가능

2. Session vs Cookie 아키텍처 설명
서버에서 조회수를 정확하게 관리하기 위해 Session 기반 구현의 단순한 로직을 선택했습니다.

    ### 세션-쿠키 동작 방식 (도서관 시스템 비유)
    
    - 서버 = 도서관
    하나의 도서관이 모든 회원의 대출 기록을 관리.
    
    - 세션 = 개별 회원의 대출기록부
    각 브라우저(회원)마다 별도의 대출기록부가 생성됨.
    한 도서관에 여러 회원의 대출기록부가 존재.
   
    - 쿠키 = 회원증
    각 브라우저가 가지고 있는 고유 식별자.
    이 회원증을 통해 자신의 대출기록부를 찾을 수 있음.
    
    ### 멀티 브라우저 환경에서의 동작
    동일한 사람이 다른 브라우저를 이용하는 경우?
      -  Chrome 접속: 'abc123' 회원증으로 식별
      -  Edge 접속: 'def456' 회원증으로 식별
      -  각각 독립적인 세션으로 관리되어 정확한 조회수 집계 가능

3. 주요 코드 변경사항
   ```js
   // controllers/portfolioController.js
    const userSession = req.session || { viewedPortfolios: {} };
    const portfolio = await incrementViewCount(id, userSession, session);
    
    // utils/viewCounter.js
    const viewKey = portfolioId;
    const lastViewTime = session.viewedPortfolios[viewKey];
    ...
    session.viewedPortfolios[viewKey] = currentTime;
   ```

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
