### PR TITLE
[FEAT] jwt 관리 방법 변경 및 내 정보 조회 API 구현

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -6,8 +6,8 @@ const redirectURL =
     : "http://localhost:8000/api/auth/github/callback";
 const frontMainURL =
   process.env.NODE_ENV === "production"
-    ? "http://localhost:5173" // 나중에 배포 주소로 변경 해야함
-    : "http://localhost:5173";
+    ? "http://localhost:5173/login" // 나중에 배포 주소로 변경 해야함
+    : "http://localhost:5173/login";
 
 const getGithubRedirectURL = (req, res) => {
   const githubAuthURL = `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${redirectURL}&scope=user`;
@@ -23,65 +23,65 @@ const getGithubCallback = async (req, res) => {
   }
 
   try {
-    // 깃허브 로그인이 불가한 개발 환경에서는 mock 데이터 사용
-    if (process.env.NODE_ENV === "development2") {
-      // Mock GitHub OAuth token response
-      const mockTokenResponse = {
-        access_token: "mock_github_access_token_123",
-        token_type: "bearer",
-        scope: "user",
-      };
+    //   // 깃허브 로그인이 불가한 개발 환경에서는 mock 데이터 사용
+    //   if (process.env.NODE_ENV === "development2") {
+    //     // Mock GitHub OAuth token response
+    //     const mockTokenResponse = {
+    //       access_token: "mock_github_access_token_123",
+    //       token_type: "bearer",
+    //       scope: "user",
+    //     };
 
-      // Mock GitHub user data
-      const mockUserData = {
-        login: "user555",
-        id: "user555",
-        name: "user555",
-      };
+    //     // Mock GitHub user data
+    //     const mockUserData = {
+    //       login: "user555",
+    //       id: "user555",
+    //       name: "user555",
+    //     };
 
-      // JWT 토큰 생성
-      const token = jwt.sign(
-        {
-          id: mockUserData.login,
-          access_token: mockTokenResponse.access_token,
-        },
-        secret,
-        {}
-      );
+    //     // JWT 토큰 생성
+    //     const token = jwt.sign(
+    //       {
+    //         id: mockUserData.login,
+    //         access_token: mockTokenResponse.access_token,
+    //       },
+    //       secret,
+    //       {}
+    //     );
 
-      // Swagger 테스트를 위해 리다이렉트 대신 JSON 응답 반환
-      const referer = req.headers.referer || "";
-      const isSwaggerRequest = referer.includes("/api-docs");
-      if (isSwaggerRequest) {
-        return res
-          .status(200)
-          .cookie("token", token, {
-            httpOnly: true,
-            secure: false,
-            sameSite: "lax",
-            path: "/",
-            maxAge: 24 * 60 * 60 * 1000,
-          })
-          .json({
-            success: true,
-            message: "Mock authentication successful",
-            userData: mockUserData,
-            token,
-          });
-      }
+    //   // Swagger 테스트를 위해 리다이렉트 대신 JSON 응답 반환
+    //   const referer = req.headers.referer || "";
+    //   const isSwaggerRequest = referer.includes("/api-docs");
+    //   if (isSwaggerRequest) {
+    //     return res
+    //       .status(200)
+    //       .cookie("token", token, {
+    //         httpOnly: true,
+    //         secure: false,
+    //         sameSite: "lax",
+    //         path: "/",
+    //         maxAge: 24 * 60 * 60 * 1000,
+    //       })
+    //       .json({
+    //         success: true,
+    //         message: "Mock authentication successful",
+    //         userData: mockUserData,
+    //         token,
+    //       });
+    //   }
 
-      // 일반 요청의 경우 기존과 동일하게 쿠키 설정 및 리다이렉트
-      return res
-        .status(201)
-        .cookie("token", token, {
-          httpOnly: true,
-          secure: false,
-          sameSite: "lax",
-          path: "/",
-          maxAge: 24 * 60 * 60 * 1000,
-        })
-        .redirect(frontMainURL);
-    }
+    //   // 일반 요청의 경우 기존과 동일하게 쿠키 설정 및 리다이렉트
+    //   return res
+    //     .status(201)
+    //     .cookie("token", token, {
+    //       httpOnly: true,
+    //       secure: false,
+    //       sameSite: "lax",
+    //       path: "/",
+    //       maxAge: 24 * 60 * 60 * 1000,
+    //     })
+    //     .redirect(frontMainURL);
+    // }
 
     // 운영 환경에서는 실제 GitHub API 호출
     //Authorization Code를 사용하여 Github Access Token 가져오기
@@ -117,22 +117,17 @@ const getGithubCallback = async (req, res) => {
 
     // 가져온 유저 ID를 JWT로 변환
     const token = jwt.sign(
-      { id: userData.login, access_token: accessToken },
+      {
+        id: userData.login,
+        name: userData.name,
+        profileImage: userData.avatar_url,
+      },
       secret,
-      {}
+      { expiresIn: "1h" }
     );
 
     // cookie에 JWT를 넣어준다.
-    res
-      .status(201)
-      .cookie("token", token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-        path: "/",
-        maxAge: 24 * 60 * 60 * 1000,
-      })
-      .redirect(frontMainURL);
+    res.status(201).redirect(`${frontMainURL}#token=${token}`);
   } catch (error) {
     console.error("Error during GitHub authentication:", error.message);
     res.status(500).json({ error: "Internal server error" });
@@ -140,13 +135,6 @@ const getGithubCallback = async (req, res) => {
 };
 
 const logout = (req, res) => {
-  // "token" 쿠키 삭제
-  res.clearCookie("token", {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-    path: "/",
-  });
   res.json("로그아웃 되었습니다.");
 };
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -27,36 +27,13 @@ const getUserInfo = async (req, res) => {
 };
 
 const registerUserProfile = async (req, res) => {
-  const { id, access_token } = req.userinfo;
-
-  // AccessToken을 사용하여 Github 유저 정보 가져오기
-  const userData = await fetch("https://api.github.com/user", {
-    headers: {
-      Authorization: `Bearer ${access_token}`,
-    },
-  }).then((res) => res.json());
-
-  const {
-    email,
-    phoneNumber,
-    links,
-    intro,
-    profileImage,
-    techStack,
-    jobGroup,
-  } = req.body;
+  const { id, name } = req.userinfo;
 
   try {
     const userDoc = await User.create({
       userID: id,
-      name: userData.name,
-      links,
-      email,
-      phoneNumber,
-      intro,
-      profileImage,
-      techStack,
-      jobGroup,
+      name,
+      ...req.body,
     });
     res.json(userDoc);
   } catch (err) {

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -107,9 +107,40 @@ const getPopularUserProfile = async (req, res) => {
   }
 };
 
+const getMyUserInfo = async (req, res) => {
+  const { id, name, profileImage } = req.userinfo;
+
+  try {
+    const user = await User.aggregate([
+      { $match: { userID: id } },
+      ...userProfilePipeline,
+    ]);
+
+    if (user.length < 1) {
+      return res.json({
+        success: true,
+        data: {
+          userID: id,
+          name,
+          profileImage,
+          newUser: true,
+        },
+      });
+    }
+
+    res.json({
+      success: true,
+      data: { ...user[0], newUser: false },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: "서버에러" });
+  }
+};
+
 module.exports = {
   getUserInfo,
   registerUserProfile,
   modifyUserProfile,
   getPopularUserProfile,
+  getMyUserInfo,
 };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -27,9 +27,9 @@ const getUserInfo = async (req, res) => {
 };
 
 const registerUserProfile = async (req, res) => {
-  const { id, name } = req.userinfo;
-
   try {
+    const { id, name } = req.userinfo;
+
     const userDoc = await User.create({
       userID: id,
       name,
@@ -45,9 +45,9 @@ const registerUserProfile = async (req, res) => {
 };
 
 const modifyUserProfile = async (req, res) => {
-  const { id } = req.userinfo;
-
   try {
+    const { id } = req.userinfo;
+
     //github 정보인 name과 userID 변경 방지
     if (req.body["name"] || req.body["userID"]) {
       return res.status(400).json({
@@ -108,9 +108,9 @@ const getPopularUserProfile = async (req, res) => {
 };
 
 const getMyUserInfo = async (req, res) => {
-  const { id, name, profileImage } = req.userinfo;
-
   try {
+    const { id, name, profileImage } = req.userinfo;
+
     const user = await User.aggregate([
       { $match: { userID: id } },
       ...userProfilePipeline,

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -3,10 +3,14 @@ const secret = process.env.JWT_SECRET;
 
 const auth = (req, res, next) => {
   // 쿠키에서 토큰 가져오기
-  const { token } = req.cookies;
+  const token = req.headers["authorization"].split(" ");
+
+  if (token[0] !== "Bearer" || token.length > 2) {
+    return res.status(401).json({ message: "유효하지 않은 토큰입니다." });
+  }
 
   // 토큰이 없는 경우
-  if (!token) {
+  if (!token[1]) {
     return res.status(401).json({ message: "인증이 필요합니다" });
   }
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -16,7 +16,7 @@ const auth = (req, res, next) => {
 
   try {
     // 토큰 검증
-    const verified = jwt.verify(token, secret);
+    const verified = jwt.verify(token[1], secret);
 
     // 검증된 사용자 정보를 request 객체에 저장
     req.userinfo = verified;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -7,6 +7,8 @@ const userController = require("../controllers/userController");
 //middleware
 const auth = require("../middleware/auth");
 
+router.get("/user", userController.getMyUserInfo);
+
 router.get("/user/:userid", userController.getUserInfo);
 
 router.get("/popular", userController.getPopularUserProfile);
@@ -62,6 +64,97 @@ module.exports = router;
  *         profileImage:
  *           type: string
  *           description: 유저 프로필 이미지 URL
+ */
+
+/**
+ * @swagger
+ * /api/users/user:
+ *   get:
+ *     summary: 내 프로필 조회
+ *     tags: [User]
+ *     responses:
+ *       200:
+ *         description: 내 프로필 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   allOf:
+ *                     - $ref: '#/components/schemas/User'
+ *                     - type: object
+ *                       properties:
+ *                         techStack:
+ *                           type: array
+ *                           items:
+ *                             allOf:
+ *                               - type: object
+ *                                 properties:
+ *                               - $ref: '#/components/schemas/TechStack'
+ *                         totalLikes:
+ *                           type: number
+ *                           example: 0
+ *                         createdAt:
+ *                           type: Date
+ *                           example: "date"
+ *                         newUser:
+ *                           type: boolean
+ *                           example: false
+ *       200-1:
+ *         description: 내 프로필 조회 성공 (신규유저)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     userID:
+ *                       type: string
+ *                       example: string
+ *                     name:
+ *                       type: string
+ *                       example: string
+ *                     profileImage:
+ *                       type: string
+ *                       example: string
+ *                     newUser:
+ *                       type: boolean
+ *                       example: false
+ *       404:
+ *         description: 유저를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 해당 ID의 유저를 찾을 수 없습니다.
+ *       500:
+ *         description: 유저를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: 서버 에러
  */
 
 /**


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
jwt 관리 방법 변경 및 내 정보 조회 API 구현

## 📌 이슈 넘버
- #68 

## 📝 작업 내용
**1. 기존 jwt 전송 방법 변경**
cookie를 사용하여 전달했던 기존 방법 대신, URI Pragment로 전달 .
client에서는 local-storage에 보관하며, Authrization 헤더에 넣어서 서버에 요청을 보낸다.

**2. jwt 데이터 변경**
access-token을 jwt에 보관하여 클라이언트에 보내는 것은 보안에 큰 문제가 있어서 삭제.
대신 profileImage와 name 필드를 추가함.
```javascript
{
        id: userData.login,
        name: userData.name,
        profileImage: userData.avatar_url,
}
```
**3. 내 정보 조회 API 추가**
유저 정보가 DB에 있으면 newUser: true 필드를 추가하여 반환 ( 유저 상세 정보 반환 )
유저 정보가 DB에 없으면 github 정보 (id, name, profileImage)와 newUser: false 필드를 반환한다.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
