### PR TITLE
♻️ 포트폴리오 조회 시 기술스택 순서 유지

### DIFF
--- a/pipeline/portfolioSearchPipeline.js
+++ b/pipeline/portfolioSearchPipeline.js
@@ -200,17 +200,18 @@ const createSearchPipeline = (params) => {
                   ],
                 },
               },
-              in: {
-                // 필요한 필드들만 명시적으로 포함
-                skill: "$$stackInfo.skill",
-                bgColor: "$$stackInfo.bgColor",
-                textColor: "$$stackInfo.textColor",
-                jobCode: "$$stackInfo.jobCode",
-              },
+              in: "$$stackInfo",
             },
           },
         },
       },
+    },
+  });
+
+  pipeline.push({
+    $project: {
+      "techStack._id": 0,
+      "techStack.__v": 0,
     },
   });
 

--- a/pipeline/portfolioSearchPipeline.js
+++ b/pipeline/portfolioSearchPipeline.js
@@ -172,24 +172,26 @@ const createSearchPipeline = (params) => {
   pipeline.push({
     $lookup: {
       from: "techstacks",
-      let: { techSkills: "$techStack" },
-      pipeline: [
-        {
-          $match: {
-            $expr: { $in: ["$skill", "$$techSkills"] },
-          },
-        },
-        {
-          $project: {
-            _id: 0,
-            skill: 1,
-            bgColor: 1,
-            textColor: 1,
-            jobCode: 1,
-          },
-        },
-      ],
+      localField: "techStack",
+      foreignField: "skill",
       as: "techStackInfo",
+    },
+  });
+
+  pipeline.push({
+    $addFields: {
+      techStackInfo: {
+        $map: {
+          input: "$techStackInfo",
+          as: "item",
+          in: {
+            skill: "$$item.skill",
+            bgColor: "$$item.bgColor",
+            textColor: "$$item.textColor",
+            jobCode: "$$item.jobCode",
+          },
+        },
+      },
     },
   });
 
@@ -215,7 +217,7 @@ const createSearchPipeline = (params) => {
       view: 1,
       images: 1,
       tags: 1,
-      techStack: "$techStackInfo",
+      techStack: 1,
       createdAt: 1,
       thumbnailImage: 1,
       userInfo: 1,

--- a/pipeline/portfolioSearchPipeline.js
+++ b/pipeline/portfolioSearchPipeline.js
@@ -180,15 +180,34 @@ const createSearchPipeline = (params) => {
 
   pipeline.push({
     $addFields: {
-      techStackInfo: {
+      techStack: {
         $map: {
-          input: "$techStackInfo",
-          as: "item",
+          input: "$techStack",
+          as: "stack",
           in: {
-            skill: "$$item.skill",
-            bgColor: "$$item.bgColor",
-            textColor: "$$item.textColor",
-            jobCode: "$$item.jobCode",
+            $let: {
+              vars: {
+                stackInfo: {
+                  $arrayElemAt: [
+                    {
+                      $filter: {
+                        input: "$techStackInfo",
+                        as: "info",
+                        cond: { $eq: ["$$stack", "$$info.skill"] },
+                      },
+                    },
+                    0,
+                  ],
+                },
+              },
+              in: {
+                // 필요한 필드들만 명시적으로 포함
+                skill: "$$stackInfo.skill",
+                bgColor: "$$stackInfo.bgColor",
+                textColor: "$$stackInfo.textColor",
+                jobCode: "$$stackInfo.jobCode",
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포트폴리오 조회 시 기술스택 순서 유지

## 📌 이슈 넘버

## 📝 작업 내용
+) 제대로 순서지켜서 나오는지 테스트 해주시면 감사합니다!
삭제할 필드(_id, __v) 만 제거되도록 했습니다.

search pipeline 변경
기존방식에서 문제점은, .... 자고 나서 찾아보겠습니다 아마 $match쪽일려나요.. .아니면 lookup단계에서 필드제거하면서 순서유지가 안됐던거같아요
1. $lookup 단계에서 techstacks 컬렉션의 데이터를 가져오고
2.  $addFields 단계에서 $map 연산자를 사용하여 techStackInfo 배열을 재구성
    - $map을 통해 techStackInfo 배열의 각 요소에 대해 필요한 필드만 선택하여 새로운 객체를 생성했습니다.
    - 이때 _id와 __v 필드는 제외되었습니다.
3.  마지막 $project 단계에서는 최종 결과에 techStackInfo 배열을 포함시킴

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
