### PR TITLE
[FIX] 포트폴리오 수정 시 이미지 인덱스 꼬임 현상 수정

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ app.use(
 
 app.use(express.json()); // JSON 파싱
 app.use(cookieParser()); // 쿠키 파싱
+app.use(express.json({ limit: "7mb" }));
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs)); // Swagger UI를 /api-docs 경로에 라우팅
 
 app.use(

--- a/middleware/upload.js
+++ b/middleware/upload.js
@@ -27,11 +27,6 @@ const fileFilter = (req, file, cb) => {
   }
 };
 
-const convertToPNG = async (file) => {
-  const pngImage = await sharp(file).png().toBuffer();
-  return pngImage;
-};
-
 // Multer S3 설정
 const upload = multer({
   storage: multerS3({
@@ -62,11 +57,8 @@ const upload = multer({
 
         //포트폴리오 컨텐트 이미지 처리
         if (usage === "content") {
-          if (!req.fileCount) {
-            req.fileCount = 0;
-          }
-          req.fileCount += 1;
-          cb(null, `${userID}/${portfolioID}/${req.fileCount}.png`);
+          const idx = file.originalname.split(".")[0];
+          cb(null, `${userID}/${portfolioID}/${idx}.png`);
         }
       } catch (error) {
         cb(error);


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
포트폴리오 수정 시 이미지 인덱스 꼬임 현상 수정

## 📌 이슈 넘버
- #87 

## 📝 작업 내용
1. 이미지 파일 명에서 인덱스를 가져와 s3에 저장
2. express json limit 설정 ( 7mb )

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
